### PR TITLE
Updates to get the ipimb IOCs working with tprs

### DIFF
--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -14,9 +14,9 @@
 # ===============================================================
 # Define the version(s) of any other needed modules 
 # ===============================================================
-EVENT2_MODULE_VERSION       = R6.0.3
-TIMESYNC_MODULE_VERSION		= R2.0.5
-TIMINGAPI_MODULE_VERSION    = R0.9
+EVENT2_MODULE_VERSION       = R6.0.5
+TIMESYNC_MODULE_VERSION     = R3.0.0
+TIMINGAPI_MODULE_VERSION    = R0.11
 
 # ============================================================
 # External Support module path definitions
@@ -40,7 +40,3 @@ EPICS_BASE = $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)
 
 # Check for invalid or undefined EPICS_BASE
 -include $(TOP)/../../EPICS_BASE.check
-
-#MY_MODULES=/reg/neh/home1/mcbrowne/trunk12/modules
-#EVENT2=$(MY_MODULES)/event2/current
-

--- a/ipimbLib/Db/Makefile
+++ b/ipimbLib/Db/Makefile
@@ -12,6 +12,7 @@ include $(TOP)/configure/CONFIG
 # databases, templates, substitutions like this
 # DB += ipimb.db
 DB += ipimb.db
+DB += ipimbTpr.db
 
 #----------------------------------------------------
 # Create and install (or just install)

--- a/ipimbLib/Db/ipimbALL.tpl-db
+++ b/ipimbLib/Db/ipimbALL.tpl-db
@@ -46,7 +46,7 @@ record(aSub, "$(RECNAME):DOREAD") {
 record(aSub, "$(RECNAME):CURRENTFID") {
     field(DESC, "Current Fiducial")
     field(SCAN, "Passive")
-    field(SNAM, "evrTimeGetFiducial")
+    field(SNAM, "$(GETFIDFUNC)")
     field(INPA, "$(RECNAME):CH0_RAW.NAME")
     field(FTA,  "STRING")
     field(FLNK, "$(RECNAME):SUM")
@@ -263,7 +263,7 @@ record(aSub, "$(RECNAME):Configure") {
     field(FTQ,  "ULONG")
     field(NOQ,  "1")
 ## Trigger enable
-    field(INPR, "$(EVR):CTRL.DG$(TRIG)E")
+    field(INPR, "$(TRIGEN)")
     field(FTR,  "ULONG")
     field(NOR,  "1")
 
@@ -285,27 +285,4 @@ record(bi, "$(RECNAME):WaitConfig") {
     field(DTYP, "IPIMB")
     field(INP,  "@$(BOX):0:DATA")
     field(PRIO, "HIGH")
-}
-
-# This record calculates the expected delay, in fiducials, between the trigger and the
-# reception of the ipimb data.  There are three factors: Delay from the event to the
-# trigger, delay from the trigger to the sample, and serial line transmission delay.
-# (This last is a 256 byte data packet, encoded as 3 bytes for every 2, sent at 115000 baud.)
-record(calc, "$(RECNAME):DATA_DELAY")
-{
-    field(DESC, "IPIMB Data Delay")
-    field(INPA, "$(EVR):CTRL.DG$(TRIG)C CPP")
-    field(INPB, "$(EVR):CTRL.DG$(TRIG)D CPP")
-    field(INPC, "$(EVR):CTRL.DG$(TRIG)W CPP")
-    field(INPD, "$(RECNAME):TrigDelay")
-    field(CALC, "(8.4e-9*A*(B+C)+D*1e-9+3.3e-3)*360")
-    field(PINI, "NO")
-}
-
-record( bi, "$(RECNAME):SYNC" )
-{
-    field( DESC, "Timestamp Synchronization" )
-    field( ZNAM, "Out of Sync" )
-    field( ONAM, "Synchronized" )
-    field( VAL, "0" )
 }

--- a/ipimbLib/Db/ipimbSyncEvr.tpl-db
+++ b/ipimbLib/Db/ipimbSyncEvr.tpl-db
@@ -1,0 +1,21 @@
+# This record calculates the expected delay, in fiducials, between the trigger and the
+# reception of the ipimb data.  There are three factors: Delay from the event to the
+# trigger, delay from the trigger to the sample, and serial line transmission delay.
+# (This last is a 256 byte data packet, encoded as 3 bytes for every 2, sent at 115000 baud.)
+record(calc, "$(RECNAME):DATA_DELAY")
+{
+    field(INPA, "$(EVR):CTRL.DG$(TRIG)C CPP")
+    field(INPB, "$(EVR):CTRL.DG$(TRIG)D CPP")
+    field(INPC, "$(EVR):CTRL.DG$(TRIG)W CPP")
+    field(INPD, "$(RECNAME):TrigDelay")
+    field(CALC, "(8.4e-9*A*(B+C)+D*1e-9+3.3e-3)*360")
+    field(PINI, "NO")
+}
+
+record( bi, "$(RECNAME):SYNC" )
+{
+    field( DESC, "Timestamp Synchronization" )
+    field( ZNAM, "Out of Sync" )
+    field( ONAM, "Synchronized" )
+    field( VAL, "0" )
+}

--- a/ipimbLib/Db/ipimbSyncTpr.tpl-db
+++ b/ipimbLib/Db/ipimbSyncTpr.tpl-db
@@ -1,0 +1,55 @@
+# This record calculates the expected delay, in fiducials, between the trigger and the
+# reception of the ipimb data.  There are three factors: Delay from the event to the
+# trigger, delay from the trigger to the sample, and serial line transmission delay.
+# (This last is a 256 byte data packet, encoded as 3 bytes for every 2, sent at 115000 baud.)
+record(calc, "$(RECNAME):DATA_DELAY")
+{
+    field(DESC, "IPIMB Data Delay")
+    field(INPA, "$(TPR):TRG$(TRIG)_TDESTICKS CPP")
+    field(INPB, "$(TPR):TRG$(TRIG)_TWIDTICKS CPP")
+    field(INPC, "$(RECNAME):TrigDelay")
+    field(CALC, "(8.4e-9*(A+B)+C*1e-9+3.3e-3)*360")
+    field(PINI, "NO")
+}
+
+record( bi, "$(RECNAME):SYNC" )
+{
+    field( DESC, "Timestamp Synchronization" )
+    field( ZNAM, "Out of Sync" )
+    field( ONAM, "Synchronized" )
+    field( VAL, "0" )
+}
+
+record(calc, "$(RECNAME):TRIGGER_CALC")
+{
+  field(DESC, "timingFifoRead event code")
+  field(CALC, "A+B")
+  field(INPA, "1000")
+  field(INPB, "$(TRIG)")
+  field(SCAN, "Passive")
+  field(PINI, "YES")
+  field(FLNK, "$(RECNAME):TRIGGER_CODE")
+}
+
+record(longin, "$(RECNAME):TRIGGER_CODE")
+{
+  field(PINI, "YES")
+  field(INP, "$(RECNAME):TRIGGER_CALC.VAL")
+}
+
+record(calc, "$(RECNAME):GEN_CALC")
+{
+  field(INPA, "$(RECNAME):TRIGGER_CODE CPP")
+  field(INPB, "$(TPR):CH$(TRIG)_EVCODE CPP")
+  field(INPC, "$(RECNAME):GEN_CALC.LA NPP")
+  field(INPD, "$(RECNAME):GEN_CALC.LB NPP")
+  field(INPE, "$(RECNAME):GEN_CALC.VAL NPP")
+  field(CALC, "E+(A!=C?1:0)+(B!=D?1:0)")
+  field(FLNK, "$(RECNAME):GEN")
+}
+
+record(longin, "$(RECNAME):GEN")
+{
+  field(PINI, "YES")
+  field(INP, "$(RECNAME):GEN_CALC.VAL")
+}

--- a/ipimbLib/Db/ipimbSyncTpr.tpl-db
+++ b/ipimbLib/Db/ipimbSyncTpr.tpl-db
@@ -2,13 +2,24 @@
 # reception of the ipimb data.  There are three factors: Delay from the event to the
 # trigger, delay from the trigger to the sample, and serial line transmission delay.
 # (This last is a 256 byte data packet, encoded as 3 bytes for every 2, sent at 115000 baud.)
+record(calc, "$(RECNAME):TRIGGER_DELAY")
+{
+  field(DESC, "IPIMB Trigger Delay")
+  field(INPA, "$(TPR):MODE CPP")
+  field(INPB, "$(TPR):TRG$(TRIG)_SYS0_TDES CPP")
+  field(INPC, "$(TPR):TRG$(TRIG)_SYS2_TDES CPP")
+  field(INPD, "$(TPR):TRG$(TRIG)_SYS0_TWID CPP")
+  field(INPE, "$(TPR):TRG$(TRIG)_SYS2_TWID CPP")
+  field(CALC, "(A==0?B+D:C+E)*1e-9")
+  field(PINI, "NO")
+}
+
 record(calc, "$(RECNAME):DATA_DELAY")
 {
     field(DESC, "IPIMB Data Delay")
-    field(INPA, "$(TPR):TRG$(TRIG)_TDESTICKS CPP")
-    field(INPB, "$(TPR):TRG$(TRIG)_TWIDTICKS CPP")
-    field(INPC, "$(RECNAME):TrigDelay")
-    field(CALC, "(8.4e-9*(A+B)+C*1e-9+3.3e-3)*360")
+    field(INPA, "$(RECNAME):TRIGGER_DELAY CPP")
+    field(INPB, "$(RECNAME):TrigDelay")
+    field(CALC, "(A+B*1e-9+3.3e-3)*360")
     field(PINI, "NO")
 }
 
@@ -37,14 +48,36 @@ record(longin, "$(RECNAME):TRIGGER_CODE")
   field(INP, "$(RECNAME):TRIGGER_CALC.VAL")
 }
 
+record(calc, "$(RECNAME):TRIGGER_MODE")
+{
+  field(INPA, "$(TPR):MODE CPP")
+  field(INPB, "0")
+  field(INPC, "$(TPR):CH$(TRIG)_RATEMODE CPP")
+  field(CALC, "A==0?B:C")
+}
+
+record(calc, "$(RECNAME):TRIGGER_STATE")
+{
+  field(INPA, "$(TPR):MODE CPP")
+  field(INPB, "$(TPR):CH$(TRIG)_RATEMODE CPP")
+  field(INPC, "$(TPR):CH$(TRIG)_FIXEDRATE CPP")
+  field(INPD, "$(TPR):CH$(TRIG)_ACRATE CPP")
+  field(INPE, "$(TPR):CH$(TRIG)_SEQCODE CPP")
+  field(INPF, "$(TPR):CH$(TRIG)_GROUP CPP")
+  field(INPG, "$(TPR):CH$(TRIG)_EVCODE CPP")
+  field(CALC, "A==1?((B==0?C:0)+(B==1?D:0)+(B==2?E:0)+(B==3?F:0)):G")
+}
+
 record(calc, "$(RECNAME):GEN_CALC")
 {
   field(INPA, "$(RECNAME):TRIGGER_CODE CPP")
-  field(INPB, "$(TPR):CH$(TRIG)_EVCODE CPP")
-  field(INPC, "$(RECNAME):GEN_CALC.LA NPP")
-  field(INPD, "$(RECNAME):GEN_CALC.LB NPP")
-  field(INPE, "$(RECNAME):GEN_CALC.VAL NPP")
-  field(CALC, "E+(A!=C?1:0)+(B!=D?1:0)")
+  field(INPB, "$(RECNAME):TRIGGER_STATE CPP")
+  field(INPC, "$(RECNAME):TRIGGER_MODE CPP")
+  field(INPD, "$(RECNAME):GEN_CALC.LA NPP")
+  field(INPE, "$(RECNAME):GEN_CALC.LB NPP")
+  field(INPF, "$(RECNAME):GEN_CALC.LC NPP")
+  field(INPG, "$(RECNAME):GEN_CALC.VAL NPP")
+  field(CALC, "G+(A!=D?1:0)+(B!=E?1:0)+(C!=F?1:0)")
   field(FLNK, "$(RECNAME):GEN")
 }
 

--- a/ipimbLib/Db/ipimbTpr.substitutions
+++ b/ipimbLib/Db/ipimbTpr.substitutions
@@ -10,10 +10,10 @@ file ipimbCH.tpl-db
 
 file ipimbALL.tpl-db
 {
-    { IOC = $(IOC), GETFIDFUNC = evrTimeGetFiducial, TRIGEN = $(EVR):CTRL.DG$(TRIG)E }
+    { IOC = $(IOC), GETFIDFUNC = ipimbGetFiducial, TRIGEN = $(TPR):CH$(TRIG)_SYS0_TCTL }
 }
 
-file ipimbSyncEvr.tpl-db
+file ipimbSyncTpr.tpl-db
 {
     { IOC = $(IOC) }
 }

--- a/ipimbLib/src/bigselRecord.c
+++ b/ipimbLib/src/bigselRecord.c
@@ -1,14 +1,13 @@
 /*************************************************************************\
-* Copyright (c) 2007 UChicago Argonne LLC, as Operator of Argonne
+* Copyright (c) 2008 UChicago Argonne LLC, as Operator of Argonne
 *     National Laboratory.
 * Copyright (c) 2002 The Regents of the University of California, as
 *     Operator of Los Alamos National Laboratory.
 * EPICS BASE is distributed subject to a Software License Agreement found
 * in file LICENSE that is included with this distribution. 
 \*************************************************************************/
-/* $Id: selRecord.c,v 1.3 2007/09/27 22:42:05 ernesto Exp $ */
 
-/* selRecord.c - Record Support Routines for Select records */
+/* bigselRecord.c - Record Support Routines for Select records */
 /*
  *      Original Author: Bob Dalesio
  *      Date:            6-2-89
@@ -30,6 +29,7 @@
 #include "errMdef.h"
 #include "recSup.h"
 #include "recGbl.h"
+
 #define GEN_SIZE_OFFSET
 #include "bigselRecord.h"
 #undef  GEN_SIZE_OFFSET
@@ -38,21 +38,21 @@
 /* Create RSET - Record Support Entry Table*/
 #define report NULL
 #define initialize NULL
-static long init_record();
-static long process();
+static long init_record(struct dbCommon *, int);
+static long process(struct dbCommon *);
 #define special NULL
 #define get_value NULL
 #define cvt_dbaddr NULL
 #define get_array_info NULL
 #define put_array_info NULL
-static long get_units();
-static long get_precision();
+static long get_units(DBADDR *, char *);
+static long get_precision(const DBADDR *, long *);
 #define get_enum_str NULL
 #define get_enum_strs NULL
 #define put_enum_str NULL
-static long get_graphic_double();
-static long get_control_double();
-static long get_alarm_double();
+static long get_graphic_double(DBADDR *, struct dbr_grDouble *);
+static long get_control_double(DBADDR *, struct dbr_ctrlDouble *);
+static long get_alarm_double(DBADDR *, struct dbr_alDouble *);
 
 rset bigselRSET={
 	RSETNUMBER,
@@ -76,85 +76,84 @@ rset bigselRSET={
 };
 epicsExportAddress(rset,bigselRSET);
 
-#define	SEL_MAX	16
+#define	SEL_MAX	12
 
-static void checkAlarms();
-static void do_sel();
-static int fetch_values();
-static void monitor();
-
-/* This needed to prevent the MS optimizer from barfing */
-static double divide(double num, double den) { return num / den; }
+static void checkAlarms(bigselRecord *);
+static void do_sel(bigselRecord *);
+static int fetch_values(bigselRecord *);
+static void monitor(bigselRecord *);
 
 
-static long init_record(struct bigselRecord *psel, int pass)
+static long init_record(struct dbCommon *pcommon, int pass)
 {
+    struct bigselRecord *prec = (struct bigselRecord *)pcommon;
     struct link *plink;
     int i;
     double *pvalue;
-    double NaN = divide(0.0, 0.0);
 
-    if (pass==0) return(0);
+    if (pass==0)
+        return 0;
 
     /* get seln initial value if nvl is a constant*/
-    if (psel->nvl.type == CONSTANT ) {
-	recGblInitConstantLink(&psel->nvl,DBF_USHORT,&psel->seln);
-    }
+    recGblInitConstantLink(&prec->nvl, DBF_USHORT, &prec->seln);
 
-    plink = &psel->inpa;
-    pvalue = &psel->a;
-    for(i=0; i<SEL_MAX; i++, plink++, pvalue++) {
-	*pvalue = NaN;
-	if (plink->type==CONSTANT) {
-	    recGblInitConstantLink(plink,DBF_DOUBLE,pvalue);
-	}
+    plink = &prec->inpa;
+    pvalue = &prec->a;
+    for (i=0; i<SEL_MAX; i++, plink++, pvalue++) {
+        *pvalue = epicsNAN;
+        recGblInitConstantLink(plink, DBF_DOUBLE, pvalue);
     }
-    return(0);
+    return 0;
 }
 
-static long process(struct bigselRecord *psel)
+static long process(struct dbCommon *pcommon)
 {
-    psel->pact = TRUE;
-    if ( RTN_SUCCESS(fetch_values(psel)) ) {
-	do_sel(psel);
+    struct bigselRecord *prec = (struct bigselRecord *)pcommon;
+    prec->pact = TRUE;
+    if ( RTN_SUCCESS(fetch_values(prec)) ) {
+	do_sel(prec);
     }
 
-    recGblGetTimeStamp(psel);
+    recGblGetTimeStamp(prec);
     /* check for alarms */
-    checkAlarms(psel);
+    checkAlarms(prec);
 
 
     /* check event list */
-    monitor(psel);
+    monitor(prec);
 
     /* process the forward scan link record */
-    recGblFwdLink(psel);
+    recGblFwdLink(prec);
 
-    psel->pact=FALSE;
+    prec->pact=FALSE;
     return(0);
 }
 
 
-static long get_units(struct dbAddr *paddr, char *units)
-{
-    struct bigselRecord	*psel=(struct bigselRecord *)paddr->precord;
+#define indexof(field) bigselRecord##field
 
-    strncpy(units,psel->egu,DB_UNITS_SIZE);
+static long get_units(DBADDR *paddr, char *units)
+{
+    bigselRecord	*prec=(bigselRecord *)paddr->precord;
+
+    if(paddr->pfldDes->field_type == DBF_DOUBLE) {
+        strncpy(units,prec->egu,DB_UNITS_SIZE);
+    }
     return(0);
 }
 
-static long get_precision(struct dbAddr *paddr, long *precision)
+static long get_precision(const DBADDR *paddr, long *precision)
 {
-    struct bigselRecord	*psel=(struct bigselRecord *)paddr->precord;
+    bigselRecord	*prec=(bigselRecord *)paddr->precord;
     double *pvalue,*plvalue;
     int i;
 
-    *precision = psel->prec;
-    if(paddr->pfield==(void *)&psel->val){
+    *precision = prec->prec;
+    if(paddr->pfield==(void *)&prec->val){
         return(0);
     }
-    pvalue = &psel->a;
-    plvalue = &psel->la;
+    pvalue = &prec->a;
+    plvalue = &prec->la;
     for(i=0; i<SEL_MAX; i++, pvalue++, plvalue++) {
 	if(paddr->pfield==(void *)&pvalue
 	|| paddr->pfield==(void *)&plvalue){
@@ -166,259 +165,266 @@ static long get_precision(struct dbAddr *paddr, long *precision)
 }
 
 
-static long get_graphic_double(struct dbAddr *paddr, struct dbr_grDouble *pgd)
+static long get_graphic_double(DBADDR *paddr, struct dbr_grDouble *pgd)
 {
-    struct bigselRecord	*psel=(struct bigselRecord *)paddr->precord;
-
-    if(paddr->pfield==(void *)&psel->val
-    || paddr->pfield==(void *)&psel->hihi
-    || paddr->pfield==(void *)&psel->high
-    || paddr->pfield==(void *)&psel->low
-    || paddr->pfield==(void *)&psel->lolo){
-	pgd->upper_disp_limit = psel->hopr;
-	pgd->lower_disp_limit = psel->lopr;
-	return(0);
+    bigselRecord	*prec=(bigselRecord *)paddr->precord;
+    int index = dbGetFieldIndex(paddr);
+    
+    switch (index) {
+        case indexof(VAL):
+        case indexof(HIHI):
+        case indexof(HIGH):
+        case indexof(LOW):
+        case indexof(LOLO):
+        case indexof(LALM):
+        case indexof(ALST):
+        case indexof(MLST):
+#ifdef __GNUC__
+        case indexof(A) ... indexof(L):
+        case indexof(LA) ... indexof(LL):
+            break;
+        default:
+#else
+            break;
+        default:
+            if((index >= indexof(A) && index <= indexof(L))
+            || (index >= indexof(LA) && index <= indexof(LL)))
+                break;
+#endif
+            recGblGetGraphicDouble(paddr,pgd);
+            return(0);
     }
-
-    if(paddr->pfield>=(void *)&psel->a && paddr->pfield<=(void *)&psel->l){
-	pgd->upper_disp_limit = psel->hopr;
-	pgd->lower_disp_limit = psel->lopr;
-	return(0);
-    }
-    if(paddr->pfield>=(void *)&psel->la && paddr->pfield<=(void *)&psel->ll){
-	pgd->upper_disp_limit = psel->hopr;
-	pgd->lower_disp_limit = psel->lopr;
-	return(0);
-    }
-    recGblGetGraphicDouble(paddr,pgd);
+    pgd->upper_disp_limit = prec->hopr;
+    pgd->lower_disp_limit = prec->lopr;
     return(0);
 }
 
 static long get_control_double(struct dbAddr *paddr, struct dbr_ctrlDouble *pcd)
 {
-    struct bigselRecord	*psel=(struct bigselRecord *)paddr->precord;
-
-    if(paddr->pfield==(void *)&psel->val
-    || paddr->pfield==(void *)&psel->hihi
-    || paddr->pfield==(void *)&psel->high
-    || paddr->pfield==(void *)&psel->low
-    || paddr->pfield==(void *)&psel->lolo){
-	pcd->upper_ctrl_limit = psel->hopr;
-	pcd->lower_ctrl_limit = psel->lopr;
-	return(0);
+    bigselRecord	*prec=(bigselRecord *)paddr->precord;
+    int index = dbGetFieldIndex(paddr);
+    
+    switch (index) {
+        case indexof(VAL):
+        case indexof(HIHI):
+        case indexof(HIGH):
+        case indexof(LOW):
+        case indexof(LOLO):
+        case indexof(LALM):
+        case indexof(ALST):
+        case indexof(MLST):
+#ifdef __GNUC__
+        case indexof(A) ... indexof(L):
+        case indexof(LA) ... indexof(LL):
+            break;
+        default:
+#else
+            break;
+        default:
+            if((index >= indexof(A) && index <= indexof(L))
+            || (index >= indexof(LA) && index <= indexof(LL)))
+                break;
+#endif
+            recGblGetControlDouble(paddr,pcd);
+            return(0);
     }
-
-    if(paddr->pfield>=(void *)&psel->a && paddr->pfield<=(void *)&psel->l){
-	pcd->upper_ctrl_limit = psel->hopr;
-	pcd->lower_ctrl_limit = psel->lopr;
-	return(0);
-    }
-    if(paddr->pfield>=(void *)&psel->la && paddr->pfield<=(void *)&psel->ll){
-	pcd->upper_ctrl_limit = psel->hopr;
-	pcd->lower_ctrl_limit = psel->lopr;
-	return(0);
-    }
-    recGblGetControlDouble(paddr,pcd);
+    pcd->upper_ctrl_limit = prec->hopr;
+    pcd->lower_ctrl_limit = prec->lopr;
     return(0);
 }
 
-static long get_alarm_double(struct dbAddr *paddr, struct dbr_alDouble *pad)
+static long get_alarm_double(DBADDR *paddr, struct dbr_alDouble *pad)
 {
-    struct bigselRecord	*psel=(struct bigselRecord *)paddr->precord;
+    bigselRecord	*prec=(bigselRecord *)paddr->precord;
 
-    if(paddr->pfield==(void *)&psel->val ){
-	pad->upper_alarm_limit = psel->hihi;
-	pad->upper_warning_limit = psel->high;
-	pad->lower_warning_limit = psel->low;
-	pad->lower_alarm_limit = psel->lolo;
+    if(dbGetFieldIndex(paddr) == indexof(VAL)) {
+        pad->upper_alarm_limit = prec->hhsv ? prec->hihi : epicsNAN;
+        pad->upper_warning_limit = prec->hsv ? prec->high : epicsNAN;
+        pad->lower_warning_limit = prec->lsv ? prec->low : epicsNAN;
+        pad->lower_alarm_limit = prec->llsv ? prec->lolo : epicsNAN;
     } else recGblGetAlarmDouble(paddr,pad);
     return(0);
 }
 
-static void checkAlarms(struct bigselRecord *psel)
+static void checkAlarms(bigselRecord *prec)
 {
-    double		val;
-    double		hyst, lalm, hihi, high, low, lolo;
-    unsigned short	hhsv, llsv, hsv, lsv;
+    double val, hyst, lalm;
+    double alev;
+    epicsEnum16 asev;
 
-    if (psel->udf){
-	recGblSetSevr(psel,UDF_ALARM,INVALID_ALARM);
-	return;
+    if (prec->udf) {
+        recGblSetSevr(prec, UDF_ALARM, prec->udfs);
+        return;
     }
-    hihi = psel->hihi; lolo = psel->lolo; high = psel->high; low = psel->low;
-    hhsv = psel->hhsv; llsv = psel->llsv; hsv = psel->hsv; lsv = psel->lsv;
-    val = psel->val; hyst = psel->hyst; lalm = psel->lalm;
+
+    val = prec->val;
+    hyst = prec->hyst;
+    lalm = prec->lalm;
 
     /* alarm condition hihi */
-    if (hhsv && (val >= hihi || ((lalm==hihi) && (val >= hihi-hyst)))){
-	if (recGblSetSevr(psel,HIHI_ALARM,psel->hhsv)) psel->lalm = hihi;
-	return;
+    asev = prec->hhsv;
+    alev = prec->hihi;
+    if (asev && (val >= alev || ((lalm == alev) && (val >= alev - hyst)))) {
+        if (recGblSetSevr(prec, HIHI_ALARM, asev))
+            prec->lalm = alev;
+        return;
     }
 
     /* alarm condition lolo */
-    if (llsv && (val <= lolo || ((lalm==lolo) && (val <= lolo+hyst)))){
-	if (recGblSetSevr(psel,LOLO_ALARM,psel->llsv)) psel->lalm = lolo;
-	return;
+    asev = prec->llsv;
+    alev = prec->lolo;
+    if (asev && (val <= alev || ((lalm == alev) && (val <= alev + hyst)))) {
+        if (recGblSetSevr(prec, LOLO_ALARM, asev))
+            prec->lalm = alev;
+        return;
     }
 
     /* alarm condition high */
-    if (hsv && (val >= high || ((lalm==high) && (val >= high-hyst)))){
-	if (recGblSetSevr(psel,HIGH_ALARM,psel->hsv)) psel->lalm = high;
-	return;
+    asev = prec->hsv;
+    alev = prec->high;
+    if (asev && (val >= alev || ((lalm == alev) && (val >= alev - hyst)))) {
+        if (recGblSetSevr(prec, HIGH_ALARM, asev))
+            prec->lalm = alev;
+        return;
     }
 
     /* alarm condition low */
-    if (lsv && (val <= low || ((lalm==low) && (val <= low+hyst)))){
-	if (recGblSetSevr(psel,LOW_ALARM,psel->lsv)) psel->lalm = low;
-	return;
+    asev = prec->lsv;
+    alev = prec->low;
+    if (asev && (val <= alev || ((lalm == alev) && (val <= alev + hyst)))) {
+        if (recGblSetSevr(prec, LOW_ALARM, asev))
+            prec->lalm = alev;
+        return;
     }
 
     /* we get here only if val is out of alarm by at least hyst */
-    psel->lalm = val;
+    prec->lalm = val;
     return;
 }
 
-static void monitor(struct bigselRecord *psel)
+static void monitor(bigselRecord *prec)
 {
-    unsigned short	monitor_mask;
-    double		delta;
+    unsigned    monitor_mask;
     double		*pnew;
     double		*pprev;
     int			i;
 
-    monitor_mask = recGblResetAlarms(psel);
+    monitor_mask = recGblResetAlarms(prec);
+
     /* check for value change */
-    delta = psel->mlst - psel->val;
-    if(delta<0.0) delta = -delta;
-    if (delta > psel->mdel) {
-        /* post events for value change */
-        monitor_mask |= DBE_VALUE;
-        /* update last value monitored */
-        psel->mlst = psel->val;
-    }
+    recGblCheckDeadband(&prec->mlst, prec->val, prec->mdel, &monitor_mask, DBE_VALUE);
+
     /* check for archive change */
-    delta = psel->alst - psel->val;
-    if(delta<0.0) delta = -delta;
-    if (delta > psel->adel) {
-        /* post events on value field for archive change */
-        monitor_mask |= DBE_LOG;
-        /* update last archive value monitored */
-        psel->alst = psel->val;
-    }
+    recGblCheckDeadband(&prec->alst, prec->val, prec->adel, &monitor_mask, DBE_ARCHIVE);
 
     /* send out monitors connected to the value field */
     if (monitor_mask)
-        db_post_events(psel, &psel->val, monitor_mask);
+        db_post_events(prec, &prec->val, monitor_mask);
 
     monitor_mask |= DBE_VALUE|DBE_LOG;
 
     /* trigger monitors of the SELN field */
-    if (psel->nlst != psel->seln) {
-	psel->nlst = psel->seln;
-	db_post_events(psel, &psel->seln, monitor_mask);
+    if (prec->nlst != prec->seln) {
+	prec->nlst = prec->seln;
+	db_post_events(prec, &prec->seln, monitor_mask);
     }
 
     /* check all input fields for changes, even if VAL hasn't changed */
-    for(i=0, pnew=&psel->a, pprev=&psel->la; i<SEL_MAX; i++, pnew++, pprev++) {
+    for(i=0, pnew=&prec->a, pprev=&prec->la; i<SEL_MAX; i++, pnew++, pprev++) {
 	if(*pnew != *pprev) {
-	    db_post_events(psel, pnew, monitor_mask);
+	    db_post_events(prec, pnew, monitor_mask);
 	    *pprev = *pnew;
 	}
     }
     return;
 }
 
-static void do_sel(struct bigselRecord *psel)
+static void do_sel(bigselRecord *prec)
 {
     double		*pvalue;
-    struct link		*plink;
     double		order[SEL_MAX];
-    unsigned short	order_inx;
+    unsigned short	count;
     unsigned short	i,j;
     double		val;
 
     /* selection mechanism */
-    pvalue = &psel->a;
-    switch (psel->selm){
+    pvalue = &prec->a;
+    switch (prec->selm){
     case (selSELM_Specified):
-	if (psel->seln >= SEL_MAX) {
-	    recGblSetSevr(psel,SOFT_ALARM,INVALID_ALARM);
-	    return;
-	}
-	val = *(pvalue+psel->seln);
-	break;
+        if (prec->seln >= SEL_MAX) {
+            recGblSetSevr(prec,SOFT_ALARM,INVALID_ALARM);
+            return;
+        }
+        val = *(pvalue+prec->seln);
+        break;
     case (selSELM_High_Signal):
-	val = divide(-1.0, 0.0); /* Start at -Inf */
-	for (i = 0; i < SEL_MAX; i++,pvalue++){
-	    if (!isnan(*pvalue) && val < *pvalue) {
-		val = *pvalue;
-		psel->seln = i;
-	    }
-	}
-	break;
+        val = -epicsINF;
+        for (i = 0; i < SEL_MAX; i++,pvalue++){
+            if (!isnan(*pvalue) && val < *pvalue) {
+                val = *pvalue;
+                prec->seln = i;
+            }
+        }
+        break;
     case (selSELM_Low_Signal):
-	val = divide(1.0, 0.0); /* Start at +Inf */
-	for (i = 0; i < SEL_MAX; i++,pvalue++){
-	    if (!isnan(*pvalue) && val > *pvalue) {
-		val = *pvalue;
-		psel->seln = i;
-	    }
-	}
-	break;
+        val = epicsINF;
+        for (i = 0; i < SEL_MAX; i++,pvalue++){
+            if (!isnan(*pvalue) && val > *pvalue) {
+                val = *pvalue;
+                prec->seln = i;
+            }
+        }
+        break;
     case (selSELM_Median_Signal):
-	plink = &psel->inpa;
-	order_inx = 0;
-	for (i = 0; i < SEL_MAX; i++,pvalue++,plink++){
-	    if (!isnan(*pvalue)){
-		j = order_inx;
-		while ((order[j-1] > *pvalue) && (j > 0)){
-		    order[j] = order[j-1];
-		    j--;
-		}
-		order[j] = *pvalue;
-		order_inx++;
-	    }
-	}
-	psel->seln = order_inx/2;
-	val = order[psel->seln];
-	break;
+        count = 0;
+        order[0] = epicsNAN;
+        for (i = 0; i < SEL_MAX; i++,pvalue++){
+            if (!isnan(*pvalue)){
+                /* Insertion sort */
+                j = count;
+                while ((j > 0) && (order[j-1] > *pvalue)){
+                    order[j] = order[j-1];
+                    j--;
+                }
+                order[j] = *pvalue;
+                count++;
+            }
+        }
+        prec->seln = count;
+        val = order[count / 2];
+        break;
     default:
-	recGblSetSevr(psel,CALC_ALARM,INVALID_ALARM);
-	return;
+        recGblSetSevr(prec,CALC_ALARM,INVALID_ALARM);
+        return;
     }
-    if (!isinf(val)){
-	psel->val=val;
-	psel->udf=isnan(psel->val);
-    }  else {
-	recGblSetSevr(psel,UDF_ALARM,MAJOR_ALARM);
-	/* If UDF is TRUE this alarm will be overwritten by checkAlarms*/
-    }
+    prec->val = val;
+    prec->udf = isnan(prec->val);
     return;
 }
-
+
 /*
  * FETCH_VALUES
  *
  * fetch the values for the variables from which to select
  */
-static int fetch_values(struct bigselRecord *psel)
+static int fetch_values(bigselRecord *prec)
 {
     struct link	*plink;
     double	*pvalue;
     int		i;
     long	status;
 
-    plink = &psel->inpa;
-    pvalue = &psel->a;
+    plink = &prec->inpa;
+    pvalue = &prec->a;
     /* If mechanism is selSELM_Specified, only get the selected input*/
-    if(psel->selm == selSELM_Specified) {
+    if(prec->selm == selSELM_Specified) {
 	/* fetch the select index */
-	status=dbGetLink(&(psel->nvl),DBR_USHORT,&(psel->seln),0,0);
-	if (!RTN_SUCCESS(status) || (psel->seln >= SEL_MAX))
+	status=dbGetLink(&(prec->nvl),DBR_USHORT,&(prec->seln),0,0);
+	if (!RTN_SUCCESS(status) || (prec->seln >= SEL_MAX))
 	    return(status);
 
-	plink += psel->seln;
-	pvalue += psel->seln;
+	plink += prec->seln;
+	pvalue += prec->seln;
 
 	status=dbGetLink(plink,DBR_DOUBLE, pvalue,0,0);
 	return(status);

--- a/ipimbLib/src/bigselRecord.h
+++ b/ipimbLib/src/bigselRecord.h
@@ -1,488 +1,506 @@
-#ifndef INCselSELMH
-#define INCselSELMH
-typedef enum {
-	selSELM_Specified,
-	selSELM_High_Signal,
-	selSELM_Low_Signal,
-	selSELM_Median_Signal
-}selSELM;
-#endif /*INCselSELMH*/
+#ifndef INC_bigselRecord_H
+#define INC_bigselRecord_H
 
-#ifndef INCbigselH
-#define INCbigselH
 #include "epicsTypes.h"
 #include "link.h"
 #include "epicsMutex.h"
 #include "ellLib.h"
 #include "epicsTime.h"
+
+#ifndef selSELM_NUM_CHOICES
+typedef enum {
+    selSELM_Specified               /* Specified */,
+    selSELM_High_Signal             /* High Signal */,
+    selSELM_Low_Signal              /* Low Signal */,
+    selSELM_Median_Signal           /* Median Signal */
+} selSELM;
+#define selSELM_NUM_CHOICES 4
+#endif
+
 typedef struct bigselRecord {
-	char		name[61];	/* Record Name */
-	char		desc[41];	/* Descriptor */
-	char		asg[29];	/* Access Security Group */
-	epicsEnum16	scan;	/* Scan Mechanism */
-	epicsEnum16	pini;	/* Process at iocInit */
-	epicsInt16	phas;	/* Scan Phase */
-	epicsInt16	evnt;	/* Event Number */
-	epicsInt16	tse;	/* Time Stamp Event */
-	DBLINK		tsel;	/* Time Stamp Link */
-	epicsEnum16	dtyp;	/* Device Type */
-	epicsInt16	disv;	/* Disable Value */
-	epicsInt16	disa;	/* Disable */
-	DBLINK		sdis;	/* Scanning Disable */
-	epicsMutexId	mlok;	/* Monitor lock */
-	ELLLIST		mlis;	/* Monitor List */
-	epicsUInt8	disp;	/* Disable putField */
-	epicsUInt8	proc;	/* Force Processing */
-	epicsEnum16	stat;	/* Alarm Status */
-	epicsEnum16	sevr;	/* Alarm Severity */
-	epicsEnum16	nsta;	/* New Alarm Status */
-	epicsEnum16	nsev;	/* New Alarm Severity */
-	epicsEnum16	acks;	/* Alarm Ack Severity */
-	epicsEnum16	ackt;	/* Alarm Ack Transient */
-	epicsEnum16	diss;	/* Disable Alarm Sevrty */
-	epicsUInt8	lcnt;	/* Lock Count */
-	epicsUInt8	pact;	/* Record active */
-	epicsUInt8	putf;	/* dbPutField process */
-	epicsUInt8	rpro;	/* Reprocess  */
-	struct asgMember *asp;	/* Access Security Pvt */
-	struct putNotify *ppn;	/* addr of PUTNOTIFY */
-	struct putNotifyRecord *ppnr;	/* pputNotifyRecord */
-	struct scan_element *spvt;	/* Scan Private */
-	struct rset	*rset;	/* Address of RSET */
-	struct dset	*dset;	/* DSET address */
-	void		*dpvt;	/* Device Private */
-	struct dbRecordType *rdes;	/* Address of dbRecordType */
-	struct lockRecord *lset;	/* Lock Set */
-	epicsEnum16	prio;	/* Scheduling Priority */
-	epicsUInt8	tpro;	/* Trace Processing */
-	char bkpt;	/* Break Point */
-	epicsUInt8	udf;	/* Undefined */
-	epicsTimeStamp	time;	/* Time */
-	DBLINK		flnk;	/* Forward Process Link */
-	epicsFloat64	val;	/* Result */
-	epicsEnum16	selm;	/* Select Mechanism */
-	epicsUInt16	seln;	/* Index value */
-	epicsInt16	prec;	/* Display Precision */
-	DBLINK		nvl;	/* Index Value Location */
-	DBLINK		inpa;	/* Input A */
-	DBLINK		inpb;	/* Input B */
-	DBLINK		inpc;	/* Input C */
-	DBLINK		inpd;	/* Input D */
-	DBLINK		inpe;	/* Input E */
-	DBLINK		inpf;	/* Input F */
-	DBLINK		inpg;	/* Input G */
-	DBLINK		inph;	/* Input H */
-	DBLINK		inpi;	/* Input I */
-	DBLINK		inpj;	/* Input J */
-	DBLINK		inpk;	/* Input K */
-	DBLINK		inpl;	/* Input L */
-	DBLINK		inpm;	/* Input M */
-	DBLINK		inpn;	/* Input N */
-	DBLINK		inpo;	/* Input O */
-	DBLINK		inpp;	/* Input P */
-	char		egu[16];	/* Units Name */
-	epicsFloat64	hopr;	/* High Operating Rng */
-	epicsFloat64	lopr;	/* Low Operating Range */
-	epicsFloat64	hihi;	/* Hihi Alarm Limit */
-	epicsFloat64	lolo;	/* Lolo Alarm Limit */
-	epicsFloat64	high;	/* High Alarm Limit */
-	epicsFloat64	low;	/* Low Alarm Limit */
-	epicsEnum16	hhsv;	/* Hihi Severity */
-	epicsEnum16	llsv;	/* Lolo Severity */
-	epicsEnum16	hsv;	/* High Severity */
-	epicsEnum16	lsv;	/* Low Severity */
-	epicsFloat64	hyst;	/* Alarm Deadband */
-	epicsFloat64	adel;	/* Archive Deadband */
-	epicsFloat64	mdel;	/* Monitor Deadband */
-	epicsFloat64	a;	/* Value of Input A */
-	epicsFloat64	b;	/* Value of Input B */
-	epicsFloat64	c;	/* Value of Input C */
-	epicsFloat64	d;	/* Value of Input D */
-	epicsFloat64	e;	/* Value of Input E */
-	epicsFloat64	f;	/* Value of Input F */
-	epicsFloat64	g;	/* Value of Input G */
-	epicsFloat64	h;	/* Value of Input H */
-	epicsFloat64	i;	/* Value of Input I */
-	epicsFloat64	j;	/* Value of Input J */
-	epicsFloat64	k;	/* Value of Input K */
-	epicsFloat64	l;	/* Value of Input L */
-	epicsFloat64	m;	/* Value of Input M */
-	epicsFloat64	n;	/* Value of Input N */
-	epicsFloat64	o;	/* Value of Input O */
-	epicsFloat64	p;	/* Value of Input P */
-	epicsFloat64	la;	/* Prev Value of A */
-	epicsFloat64	lb;	/* Prev Value of B */
-	epicsFloat64	lc;	/* Prev Value of C */
-	epicsFloat64	ld;	/* Prev Value of D */
-	epicsFloat64	le;	/* Prev Value of E */
-	epicsFloat64	lf;	/* Prev Value of F */
-	epicsFloat64	lg;	/* Prev Value of G */
-	epicsFloat64	lh;	/* Prev Value of H */
-	epicsFloat64	li;	/* Prev Value of I */
-	epicsFloat64	lj;	/* Prev Value of J */
-	epicsFloat64	lk;	/* Prev Value of K */
-	epicsFloat64	ll;	/* Prev Value of L */
-	epicsFloat64	lm;	/* Prev Value of M */
-	epicsFloat64	ln;	/* Prev Value of N */
-	epicsFloat64	lo;	/* Prev Value of O */
-	epicsFloat64	lp;	/* Prev Value of P */
-	epicsFloat64	lalm;	/* Last Value Alarmed */
-	epicsFloat64	alst;	/* Last Value Archived */
-	epicsFloat64	mlst;	/* Last Val Monitored */
-	epicsUInt16	nlst;	/* Last Index Monitored */
+    char                    name[61];   /* Record Name */
+    char                    desc[41];   /* Descriptor */
+    char                    asg[29];    /* Access Security Group */
+    epicsEnum16             scan;       /* Scan Mechanism */
+    epicsEnum16             pini;       /* Process at iocInit */
+    epicsInt16              phas;       /* Scan Phase */
+    char                    evnt[40];   /* Event Number */
+    epicsInt16              tse;        /* Time Stamp Event */
+    DBLINK                  tsel;       /* Time Stamp Link */
+    epicsEnum16             dtyp;       /* Device Type */
+    epicsInt16              disv;       /* Disable Value */
+    epicsInt16              disa;       /* Disable */
+    DBLINK                  sdis;       /* Scanning Disable */
+    epicsMutexId            mlok;       /* Monitor lock */
+    ELLLIST                 mlis;       /* Monitor List */
+    ELLLIST                 bklnk;      /* Backwards link tracking */
+    epicsUInt8              disp;       /* Disable putField */
+    epicsUInt8              proc;       /* Force Processing */
+    epicsEnum16             stat;       /* Alarm Status */
+    epicsEnum16             sevr;       /* Alarm Severity */
+    epicsEnum16             nsta;       /* New Alarm Status */
+    epicsEnum16             nsev;       /* New Alarm Severity */
+    epicsEnum16             acks;       /* Alarm Ack Severity */
+    epicsEnum16             ackt;       /* Alarm Ack Transient */
+    epicsEnum16             diss;       /* Disable Alarm Sevrty */
+    epicsUInt8              lcnt;       /* Lock Count */
+    epicsUInt8              pact;       /* Record active */
+    epicsUInt8              putf;       /* dbPutField process */
+    epicsUInt8              rpro;       /* Reprocess  */
+    struct asgMember        *asp;       /* Access Security Pvt */
+    struct processNotify    *ppn;       /* addr of PUTNOTIFY */
+    struct processNotifyRecord *ppnr;   /* pputNotifyRecord */
+    struct scan_element     *spvt;      /* Scan Private */
+    struct typed_rset       *rset;      /* Address of RSET */
+    struct dset             *dset;      /* DSET address */
+    void                    *dpvt;      /* Device Private */
+    struct dbRecordType     *rdes;      /* Address of dbRecordType */
+    struct lockRecord       *lset;      /* Lock Set */
+    epicsEnum16             prio;       /* Scheduling Priority */
+    epicsUInt8              tpro;       /* Trace Processing */
+    char                    bkpt;       /* Break Point */
+    epicsUInt8              udf;        /* Undefined */
+    epicsEnum16             udfs;       /* Undefined Alarm Sevrty */
+    epicsTimeStamp          time;       /* Time */
+    DBLINK                  flnk;       /* Forward Process Link */
+    epicsFloat64            val;        /* Result */
+    epicsEnum16             selm;       /* Select Mechanism */
+    epicsUInt16             seln;       /* Index value */
+    epicsInt16              prec;       /* Display Precision */
+    DBLINK                  nvl;        /* Index Value Location */
+    DBLINK                  inpa;       /* Input A */
+    DBLINK                  inpb;       /* Input B */
+    DBLINK                  inpc;       /* Input C */
+    DBLINK                  inpd;       /* Input D */
+    DBLINK                  inpe;       /* Input E */
+    DBLINK                  inpf;       /* Input F */
+    DBLINK                  inpg;       /* Input G */
+    DBLINK                  inph;       /* Input H */
+    DBLINK                  inpi;       /* Input I */
+    DBLINK                  inpj;       /* Input J */
+    DBLINK                  inpk;       /* Input K */
+    DBLINK                  inpl;       /* Input L */
+    DBLINK                  inpm;       /* Input M */
+    DBLINK                  inpn;       /* Input N */
+    DBLINK                  inpo;       /* Input O */
+    DBLINK                  inpp;       /* Input P */
+    char                    egu[16];    /* Units Name */
+    epicsFloat64            hopr;       /* High Operating Rng */
+    epicsFloat64            lopr;       /* Low Operating Range */
+    epicsFloat64            hihi;       /* Hihi Alarm Limit */
+    epicsFloat64            lolo;       /* Lolo Alarm Limit */
+    epicsFloat64            high;       /* High Alarm Limit */
+    epicsFloat64            low;        /* Low Alarm Limit */
+    epicsEnum16             hhsv;       /* Hihi Severity */
+    epicsEnum16             llsv;       /* Lolo Severity */
+    epicsEnum16             hsv;        /* High Severity */
+    epicsEnum16             lsv;        /* Low Severity */
+    epicsFloat64            hyst;       /* Alarm Deadband */
+    epicsFloat64            adel;       /* Archive Deadband */
+    epicsFloat64            mdel;       /* Monitor Deadband */
+    epicsFloat64            a;          /* Value of Input A */
+    epicsFloat64            b;          /* Value of Input B */
+    epicsFloat64            c;          /* Value of Input C */
+    epicsFloat64            d;          /* Value of Input D */
+    epicsFloat64            e;          /* Value of Input E */
+    epicsFloat64            f;          /* Value of Input F */
+    epicsFloat64            g;          /* Value of Input G */
+    epicsFloat64            h;          /* Value of Input H */
+    epicsFloat64            i;          /* Value of Input I */
+    epicsFloat64            j;          /* Value of Input J */
+    epicsFloat64            k;          /* Value of Input K */
+    epicsFloat64            l;          /* Value of Input L */
+    epicsFloat64            m;          /* Value of Input M */
+    epicsFloat64            n;          /* Value of Input N */
+    epicsFloat64            o;          /* Value of Input O */
+    epicsFloat64            p;          /* Value of Input P */
+    epicsFloat64            la;         /* Prev Value of A */
+    epicsFloat64            lb;         /* Prev Value of B */
+    epicsFloat64            lc;         /* Prev Value of C */
+    epicsFloat64            ld;         /* Prev Value of D */
+    epicsFloat64            le;         /* Prev Value of E */
+    epicsFloat64            lf;         /* Prev Value of F */
+    epicsFloat64            lg;         /* Prev Value of G */
+    epicsFloat64            lh;         /* Prev Value of H */
+    epicsFloat64            li;         /* Prev Value of I */
+    epicsFloat64            lj;         /* Prev Value of J */
+    epicsFloat64            lk;         /* Prev Value of K */
+    epicsFloat64            ll;         /* Prev Value of L */
+    epicsFloat64            lm;         /* Prev Value of M */
+    epicsFloat64            ln;         /* Prev Value of N */
+    epicsFloat64            lo;         /* Prev Value of O */
+    epicsFloat64            lp;         /* Prev Value of P */
+    epicsFloat64            lalm;       /* Last Value Alarmed */
+    epicsFloat64            alst;       /* Last Value Archived */
+    epicsFloat64            mlst;       /* Last Val Monitored */
+    epicsUInt16             nlst;       /* Last Index Monitored */
 } bigselRecord;
-#define bigselRecordNAME	0
-#define bigselRecordDESC	1
-#define bigselRecordASG	2
-#define bigselRecordSCAN	3
-#define bigselRecordPINI	4
-#define bigselRecordPHAS	5
-#define bigselRecordEVNT	6
-#define bigselRecordTSE	7
-#define bigselRecordTSEL	8
-#define bigselRecordDTYP	9
-#define bigselRecordDISV	10
-#define bigselRecordDISA	11
-#define bigselRecordSDIS	12
-#define bigselRecordMLOK	13
-#define bigselRecordMLIS	14
-#define bigselRecordDISP	15
-#define bigselRecordPROC	16
-#define bigselRecordSTAT	17
-#define bigselRecordSEVR	18
-#define bigselRecordNSTA	19
-#define bigselRecordNSEV	20
-#define bigselRecordACKS	21
-#define bigselRecordACKT	22
-#define bigselRecordDISS	23
-#define bigselRecordLCNT	24
-#define bigselRecordPACT	25
-#define bigselRecordPUTF	26
-#define bigselRecordRPRO	27
-#define bigselRecordASP	28
-#define bigselRecordPPN	29
-#define bigselRecordPPNR	30
-#define bigselRecordSPVT	31
-#define bigselRecordRSET	32
-#define bigselRecordDSET	33
-#define bigselRecordDPVT	34
-#define bigselRecordRDES	35
-#define bigselRecordLSET	36
-#define bigselRecordPRIO	37
-#define bigselRecordTPRO	38
-#define bigselRecordBKPT	39
-#define bigselRecordUDF	40
-#define bigselRecordTIME	41
-#define bigselRecordFLNK	42
-#define bigselRecordVAL	43
-#define bigselRecordSELM	44
-#define bigselRecordSELN	45
-#define bigselRecordPREC	46
-#define bigselRecordNVL	47
-#define bigselRecordINPA	48
-#define bigselRecordINPB	49
-#define bigselRecordINPC	50
-#define bigselRecordINPD	51
-#define bigselRecordINPE	52
-#define bigselRecordINPF	53
-#define bigselRecordINPG	54
-#define bigselRecordINPH	55
-#define bigselRecordINPI	56
-#define bigselRecordINPJ	57
-#define bigselRecordINPK	58
-#define bigselRecordINPL	59
-#define bigselRecordINPM	60
-#define bigselRecordINPN	61
-#define bigselRecordINPO	62
-#define bigselRecordINPP	63
-#define bigselRecordEGU	64
-#define bigselRecordHOPR	65
-#define bigselRecordLOPR	66
-#define bigselRecordHIHI	67
-#define bigselRecordLOLO	68
-#define bigselRecordHIGH	69
-#define bigselRecordLOW	70
-#define bigselRecordHHSV	71
-#define bigselRecordLLSV	72
-#define bigselRecordHSV	73
-#define bigselRecordLSV	74
-#define bigselRecordHYST	75
-#define bigselRecordADEL	76
-#define bigselRecordMDEL	77
-#define bigselRecordA	78
-#define bigselRecordB	79
-#define bigselRecordC	80
-#define bigselRecordD	81
-#define bigselRecordE	82
-#define bigselRecordF	83
-#define bigselRecordG	84
-#define bigselRecordH	85
-#define bigselRecordI	86
-#define bigselRecordJ	87
-#define bigselRecordK	88
-#define bigselRecordL	89
-#define bigselRecordM	90
-#define bigselRecordN	91
-#define bigselRecordO	92
-#define bigselRecordP	93
-#define bigselRecordLA	94
-#define bigselRecordLB	95
-#define bigselRecordLC	96
-#define bigselRecordLD	97
-#define bigselRecordLE	98
-#define bigselRecordLF	99
-#define bigselRecordLG	100
-#define bigselRecordLH	101
-#define bigselRecordLI	102
-#define bigselRecordLJ	103
-#define bigselRecordLK	104
-#define bigselRecordLL	105
-#define bigselRecordLM	106
-#define bigselRecordLN	107
-#define bigselRecordLO	108
-#define bigselRecordLP	109
-#define bigselRecordLALM	110
-#define bigselRecordALST	111
-#define bigselRecordMLST	112
-#define bigselRecordNLST	113
-#endif /*INCbigselH*/
+
+typedef enum {
+    bigselRecordNAME = 0,
+    bigselRecordDESC = 1,
+    bigselRecordASG = 2,
+    bigselRecordSCAN = 3,
+    bigselRecordPINI = 4,
+    bigselRecordPHAS = 5,
+    bigselRecordEVNT = 6,
+    bigselRecordTSE = 7,
+    bigselRecordTSEL = 8,
+    bigselRecordDTYP = 9,
+    bigselRecordDISV = 10,
+    bigselRecordDISA = 11,
+    bigselRecordSDIS = 12,
+    bigselRecordMLOK = 13,
+    bigselRecordMLIS = 14,
+    bigselRecordBKLNK = 15,
+    bigselRecordDISP = 16,
+    bigselRecordPROC = 17,
+    bigselRecordSTAT = 18,
+    bigselRecordSEVR = 19,
+    bigselRecordNSTA = 20,
+    bigselRecordNSEV = 21,
+    bigselRecordACKS = 22,
+    bigselRecordACKT = 23,
+    bigselRecordDISS = 24,
+    bigselRecordLCNT = 25,
+    bigselRecordPACT = 26,
+    bigselRecordPUTF = 27,
+    bigselRecordRPRO = 28,
+    bigselRecordASP = 29,
+    bigselRecordPPN = 30,
+    bigselRecordPPNR = 31,
+    bigselRecordSPVT = 32,
+    bigselRecordRSET = 33,
+    bigselRecordDSET = 34,
+    bigselRecordDPVT = 35,
+    bigselRecordRDES = 36,
+    bigselRecordLSET = 37,
+    bigselRecordPRIO = 38,
+    bigselRecordTPRO = 39,
+    bigselRecordBKPT = 40,
+    bigselRecordUDF = 41,
+    bigselRecordUDFS = 42,
+    bigselRecordTIME = 43,
+    bigselRecordFLNK = 44,
+    bigselRecordVAL = 45,
+    bigselRecordSELM = 46,
+    bigselRecordSELN = 47,
+    bigselRecordPREC = 48,
+    bigselRecordNVL = 49,
+    bigselRecordINPA = 50,
+    bigselRecordINPB = 51,
+    bigselRecordINPC = 52,
+    bigselRecordINPD = 53,
+    bigselRecordINPE = 54,
+    bigselRecordINPF = 55,
+    bigselRecordINPG = 56,
+    bigselRecordINPH = 57,
+    bigselRecordINPI = 58,
+    bigselRecordINPJ = 59,
+    bigselRecordINPK = 60,
+    bigselRecordINPL = 61,
+    bigselRecordINPN = 62,
+    bigselRecordINPM = 63,
+    bigselRecordINPO = 64,
+    bigselRecordINPP = 65,
+    bigselRecordEGU = 66,
+    bigselRecordHOPR = 67,
+    bigselRecordLOPR = 68,
+    bigselRecordHIHI = 69,
+    bigselRecordLOLO = 70,
+    bigselRecordHIGH = 71,
+    bigselRecordLOW = 72,
+    bigselRecordHHSV = 73,
+    bigselRecordLLSV = 74,
+    bigselRecordHSV = 75,
+    bigselRecordLSV = 76,
+    bigselRecordHYST = 77,
+    bigselRecordADEL = 78,
+    bigselRecordMDEL = 79,
+    bigselRecordA = 80,
+    bigselRecordB = 81,
+    bigselRecordC = 82,
+    bigselRecordD = 83,
+    bigselRecordE = 84,
+    bigselRecordF = 85,
+    bigselRecordG = 86,
+    bigselRecordH = 87,
+    bigselRecordI = 88,
+    bigselRecordJ = 89,
+    bigselRecordK = 90,
+    bigselRecordL = 91,
+    bigselRecordM = 92,
+    bigselRecordN = 93,
+    bigselRecordO = 94,
+    bigselRecordP = 95,
+    bigselRecordLA = 96,
+    bigselRecordLB = 97,
+    bigselRecordLC = 98,
+    bigselRecordLD = 99,
+    bigselRecordLE = 100,
+    bigselRecordLF = 101,
+    bigselRecordLG = 102,
+    bigselRecordLH = 103,
+    bigselRecordLI = 104,
+    bigselRecordLJ = 105,
+    bigselRecordLK = 106,
+    bigselRecordLL = 107,
+    bigselRecordLM = 108,
+    bigselRecordLN = 109,
+    bigselRecordLO = 110,
+    bigselRecordLP = 111,
+    bigselRecordLALM = 112,
+    bigselRecordALST = 113,
+    bigselRecordMLST = 114,
+    bigselRecordNLST = 115
+} bigselFieldIndex;
+
 #ifdef GEN_SIZE_OFFSET
+
+#include <epicsAssert.h>
+#include <epicsExport.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
 #include <epicsExport.h>
-static int bigselRecordSizeOffset(dbRecordType *pdbRecordType)
+static int bigselRecordSizeOffset(dbRecordType *prt)
 {
     bigselRecord *prec = 0;
-  pdbRecordType->papFldDes[0]->size=sizeof(prec->name);
-  pdbRecordType->papFldDes[0]->offset=(short)((char *)&prec->name - (char *)prec);
-  pdbRecordType->papFldDes[1]->size=sizeof(prec->desc);
-  pdbRecordType->papFldDes[1]->offset=(short)((char *)&prec->desc - (char *)prec);
-  pdbRecordType->papFldDes[2]->size=sizeof(prec->asg);
-  pdbRecordType->papFldDes[2]->offset=(short)((char *)&prec->asg - (char *)prec);
-  pdbRecordType->papFldDes[3]->size=sizeof(prec->scan);
-  pdbRecordType->papFldDes[3]->offset=(short)((char *)&prec->scan - (char *)prec);
-  pdbRecordType->papFldDes[4]->size=sizeof(prec->pini);
-  pdbRecordType->papFldDes[4]->offset=(short)((char *)&prec->pini - (char *)prec);
-  pdbRecordType->papFldDes[5]->size=sizeof(prec->phas);
-  pdbRecordType->papFldDes[5]->offset=(short)((char *)&prec->phas - (char *)prec);
-  pdbRecordType->papFldDes[6]->size=sizeof(prec->evnt);
-  pdbRecordType->papFldDes[6]->offset=(short)((char *)&prec->evnt - (char *)prec);
-  pdbRecordType->papFldDes[7]->size=sizeof(prec->tse);
-  pdbRecordType->papFldDes[7]->offset=(short)((char *)&prec->tse - (char *)prec);
-  pdbRecordType->papFldDes[8]->size=sizeof(prec->tsel);
-  pdbRecordType->papFldDes[8]->offset=(short)((char *)&prec->tsel - (char *)prec);
-  pdbRecordType->papFldDes[9]->size=sizeof(prec->dtyp);
-  pdbRecordType->papFldDes[9]->offset=(short)((char *)&prec->dtyp - (char *)prec);
-  pdbRecordType->papFldDes[10]->size=sizeof(prec->disv);
-  pdbRecordType->papFldDes[10]->offset=(short)((char *)&prec->disv - (char *)prec);
-  pdbRecordType->papFldDes[11]->size=sizeof(prec->disa);
-  pdbRecordType->papFldDes[11]->offset=(short)((char *)&prec->disa - (char *)prec);
-  pdbRecordType->papFldDes[12]->size=sizeof(prec->sdis);
-  pdbRecordType->papFldDes[12]->offset=(short)((char *)&prec->sdis - (char *)prec);
-  pdbRecordType->papFldDes[13]->size=sizeof(prec->mlok);
-  pdbRecordType->papFldDes[13]->offset=(short)((char *)&prec->mlok - (char *)prec);
-  pdbRecordType->papFldDes[14]->size=sizeof(prec->mlis);
-  pdbRecordType->papFldDes[14]->offset=(short)((char *)&prec->mlis - (char *)prec);
-  pdbRecordType->papFldDes[15]->size=sizeof(prec->disp);
-  pdbRecordType->papFldDes[15]->offset=(short)((char *)&prec->disp - (char *)prec);
-  pdbRecordType->papFldDes[16]->size=sizeof(prec->proc);
-  pdbRecordType->papFldDes[16]->offset=(short)((char *)&prec->proc - (char *)prec);
-  pdbRecordType->papFldDes[17]->size=sizeof(prec->stat);
-  pdbRecordType->papFldDes[17]->offset=(short)((char *)&prec->stat - (char *)prec);
-  pdbRecordType->papFldDes[18]->size=sizeof(prec->sevr);
-  pdbRecordType->papFldDes[18]->offset=(short)((char *)&prec->sevr - (char *)prec);
-  pdbRecordType->papFldDes[19]->size=sizeof(prec->nsta);
-  pdbRecordType->papFldDes[19]->offset=(short)((char *)&prec->nsta - (char *)prec);
-  pdbRecordType->papFldDes[20]->size=sizeof(prec->nsev);
-  pdbRecordType->papFldDes[20]->offset=(short)((char *)&prec->nsev - (char *)prec);
-  pdbRecordType->papFldDes[21]->size=sizeof(prec->acks);
-  pdbRecordType->papFldDes[21]->offset=(short)((char *)&prec->acks - (char *)prec);
-  pdbRecordType->papFldDes[22]->size=sizeof(prec->ackt);
-  pdbRecordType->papFldDes[22]->offset=(short)((char *)&prec->ackt - (char *)prec);
-  pdbRecordType->papFldDes[23]->size=sizeof(prec->diss);
-  pdbRecordType->papFldDes[23]->offset=(short)((char *)&prec->diss - (char *)prec);
-  pdbRecordType->papFldDes[24]->size=sizeof(prec->lcnt);
-  pdbRecordType->papFldDes[24]->offset=(short)((char *)&prec->lcnt - (char *)prec);
-  pdbRecordType->papFldDes[25]->size=sizeof(prec->pact);
-  pdbRecordType->papFldDes[25]->offset=(short)((char *)&prec->pact - (char *)prec);
-  pdbRecordType->papFldDes[26]->size=sizeof(prec->putf);
-  pdbRecordType->papFldDes[26]->offset=(short)((char *)&prec->putf - (char *)prec);
-  pdbRecordType->papFldDes[27]->size=sizeof(prec->rpro);
-  pdbRecordType->papFldDes[27]->offset=(short)((char *)&prec->rpro - (char *)prec);
-  pdbRecordType->papFldDes[28]->size=sizeof(prec->asp);
-  pdbRecordType->papFldDes[28]->offset=(short)((char *)&prec->asp - (char *)prec);
-  pdbRecordType->papFldDes[29]->size=sizeof(prec->ppn);
-  pdbRecordType->papFldDes[29]->offset=(short)((char *)&prec->ppn - (char *)prec);
-  pdbRecordType->papFldDes[30]->size=sizeof(prec->ppnr);
-  pdbRecordType->papFldDes[30]->offset=(short)((char *)&prec->ppnr - (char *)prec);
-  pdbRecordType->papFldDes[31]->size=sizeof(prec->spvt);
-  pdbRecordType->papFldDes[31]->offset=(short)((char *)&prec->spvt - (char *)prec);
-  pdbRecordType->papFldDes[32]->size=sizeof(prec->rset);
-  pdbRecordType->papFldDes[32]->offset=(short)((char *)&prec->rset - (char *)prec);
-  pdbRecordType->papFldDes[33]->size=sizeof(prec->dset);
-  pdbRecordType->papFldDes[33]->offset=(short)((char *)&prec->dset - (char *)prec);
-  pdbRecordType->papFldDes[34]->size=sizeof(prec->dpvt);
-  pdbRecordType->papFldDes[34]->offset=(short)((char *)&prec->dpvt - (char *)prec);
-  pdbRecordType->papFldDes[35]->size=sizeof(prec->rdes);
-  pdbRecordType->papFldDes[35]->offset=(short)((char *)&prec->rdes - (char *)prec);
-  pdbRecordType->papFldDes[36]->size=sizeof(prec->lset);
-  pdbRecordType->papFldDes[36]->offset=(short)((char *)&prec->lset - (char *)prec);
-  pdbRecordType->papFldDes[37]->size=sizeof(prec->prio);
-  pdbRecordType->papFldDes[37]->offset=(short)((char *)&prec->prio - (char *)prec);
-  pdbRecordType->papFldDes[38]->size=sizeof(prec->tpro);
-  pdbRecordType->papFldDes[38]->offset=(short)((char *)&prec->tpro - (char *)prec);
-  pdbRecordType->papFldDes[39]->size=sizeof(prec->bkpt);
-  pdbRecordType->papFldDes[39]->offset=(short)((char *)&prec->bkpt - (char *)prec);
-  pdbRecordType->papFldDes[40]->size=sizeof(prec->udf);
-  pdbRecordType->papFldDes[40]->offset=(short)((char *)&prec->udf - (char *)prec);
-  pdbRecordType->papFldDes[41]->size=sizeof(prec->time);
-  pdbRecordType->papFldDes[41]->offset=(short)((char *)&prec->time - (char *)prec);
-  pdbRecordType->papFldDes[42]->size=sizeof(prec->flnk);
-  pdbRecordType->papFldDes[42]->offset=(short)((char *)&prec->flnk - (char *)prec);
-  pdbRecordType->papFldDes[43]->size=sizeof(prec->val);
-  pdbRecordType->papFldDes[43]->offset=(short)((char *)&prec->val - (char *)prec);
-  pdbRecordType->papFldDes[44]->size=sizeof(prec->selm);
-  pdbRecordType->papFldDes[44]->offset=(short)((char *)&prec->selm - (char *)prec);
-  pdbRecordType->papFldDes[45]->size=sizeof(prec->seln);
-  pdbRecordType->papFldDes[45]->offset=(short)((char *)&prec->seln - (char *)prec);
-  pdbRecordType->papFldDes[46]->size=sizeof(prec->prec);
-  pdbRecordType->papFldDes[46]->offset=(short)((char *)&prec->prec - (char *)prec);
-  pdbRecordType->papFldDes[47]->size=sizeof(prec->nvl);
-  pdbRecordType->papFldDes[47]->offset=(short)((char *)&prec->nvl - (char *)prec);
-  pdbRecordType->papFldDes[48]->size=sizeof(prec->inpa);
-  pdbRecordType->papFldDes[48]->offset=(short)((char *)&prec->inpa - (char *)prec);
-  pdbRecordType->papFldDes[49]->size=sizeof(prec->inpb);
-  pdbRecordType->papFldDes[49]->offset=(short)((char *)&prec->inpb - (char *)prec);
-  pdbRecordType->papFldDes[50]->size=sizeof(prec->inpc);
-  pdbRecordType->papFldDes[50]->offset=(short)((char *)&prec->inpc - (char *)prec);
-  pdbRecordType->papFldDes[51]->size=sizeof(prec->inpd);
-  pdbRecordType->papFldDes[51]->offset=(short)((char *)&prec->inpd - (char *)prec);
-  pdbRecordType->papFldDes[52]->size=sizeof(prec->inpe);
-  pdbRecordType->papFldDes[52]->offset=(short)((char *)&prec->inpe - (char *)prec);
-  pdbRecordType->papFldDes[53]->size=sizeof(prec->inpf);
-  pdbRecordType->papFldDes[53]->offset=(short)((char *)&prec->inpf - (char *)prec);
-  pdbRecordType->papFldDes[54]->size=sizeof(prec->inpg);
-  pdbRecordType->papFldDes[54]->offset=(short)((char *)&prec->inpg - (char *)prec);
-  pdbRecordType->papFldDes[55]->size=sizeof(prec->inph);
-  pdbRecordType->papFldDes[55]->offset=(short)((char *)&prec->inph - (char *)prec);
-  pdbRecordType->papFldDes[56]->size=sizeof(prec->inpi);
-  pdbRecordType->papFldDes[56]->offset=(short)((char *)&prec->inpi - (char *)prec);
-  pdbRecordType->papFldDes[57]->size=sizeof(prec->inpj);
-  pdbRecordType->papFldDes[57]->offset=(short)((char *)&prec->inpj - (char *)prec);
-  pdbRecordType->papFldDes[58]->size=sizeof(prec->inpk);
-  pdbRecordType->papFldDes[58]->offset=(short)((char *)&prec->inpk - (char *)prec);
-  pdbRecordType->papFldDes[59]->size=sizeof(prec->inpl);
-  pdbRecordType->papFldDes[59]->offset=(short)((char *)&prec->inpl - (char *)prec);
-  pdbRecordType->papFldDes[60]->size=sizeof(prec->inpm);
-  pdbRecordType->papFldDes[60]->offset=(short)((char *)&prec->inpm - (char *)prec);
-  pdbRecordType->papFldDes[61]->size=sizeof(prec->inpn);
-  pdbRecordType->papFldDes[61]->offset=(short)((char *)&prec->inpn - (char *)prec);
-  pdbRecordType->papFldDes[62]->size=sizeof(prec->inpo);
-  pdbRecordType->papFldDes[62]->offset=(short)((char *)&prec->inpo - (char *)prec);
-  pdbRecordType->papFldDes[63]->size=sizeof(prec->inpp);
-  pdbRecordType->papFldDes[63]->offset=(short)((char *)&prec->inpp - (char *)prec);
-  pdbRecordType->papFldDes[64]->size=sizeof(prec->egu);
-  pdbRecordType->papFldDes[64]->offset=(short)((char *)&prec->egu - (char *)prec);
-  pdbRecordType->papFldDes[65]->size=sizeof(prec->hopr);
-  pdbRecordType->papFldDes[65]->offset=(short)((char *)&prec->hopr - (char *)prec);
-  pdbRecordType->papFldDes[66]->size=sizeof(prec->lopr);
-  pdbRecordType->papFldDes[66]->offset=(short)((char *)&prec->lopr - (char *)prec);
-  pdbRecordType->papFldDes[67]->size=sizeof(prec->hihi);
-  pdbRecordType->papFldDes[67]->offset=(short)((char *)&prec->hihi - (char *)prec);
-  pdbRecordType->papFldDes[68]->size=sizeof(prec->lolo);
-  pdbRecordType->papFldDes[68]->offset=(short)((char *)&prec->lolo - (char *)prec);
-  pdbRecordType->papFldDes[69]->size=sizeof(prec->high);
-  pdbRecordType->papFldDes[69]->offset=(short)((char *)&prec->high - (char *)prec);
-  pdbRecordType->papFldDes[70]->size=sizeof(prec->low);
-  pdbRecordType->papFldDes[70]->offset=(short)((char *)&prec->low - (char *)prec);
-  pdbRecordType->papFldDes[71]->size=sizeof(prec->hhsv);
-  pdbRecordType->papFldDes[71]->offset=(short)((char *)&prec->hhsv - (char *)prec);
-  pdbRecordType->papFldDes[72]->size=sizeof(prec->llsv);
-  pdbRecordType->papFldDes[72]->offset=(short)((char *)&prec->llsv - (char *)prec);
-  pdbRecordType->papFldDes[73]->size=sizeof(prec->hsv);
-  pdbRecordType->papFldDes[73]->offset=(short)((char *)&prec->hsv - (char *)prec);
-  pdbRecordType->papFldDes[74]->size=sizeof(prec->lsv);
-  pdbRecordType->papFldDes[74]->offset=(short)((char *)&prec->lsv - (char *)prec);
-  pdbRecordType->papFldDes[75]->size=sizeof(prec->hyst);
-  pdbRecordType->papFldDes[75]->offset=(short)((char *)&prec->hyst - (char *)prec);
-  pdbRecordType->papFldDes[76]->size=sizeof(prec->adel);
-  pdbRecordType->papFldDes[76]->offset=(short)((char *)&prec->adel - (char *)prec);
-  pdbRecordType->papFldDes[77]->size=sizeof(prec->mdel);
-  pdbRecordType->papFldDes[77]->offset=(short)((char *)&prec->mdel - (char *)prec);
-  pdbRecordType->papFldDes[78]->size=sizeof(prec->a);
-  pdbRecordType->papFldDes[78]->offset=(short)((char *)&prec->a - (char *)prec);
-  pdbRecordType->papFldDes[79]->size=sizeof(prec->b);
-  pdbRecordType->papFldDes[79]->offset=(short)((char *)&prec->b - (char *)prec);
-  pdbRecordType->papFldDes[80]->size=sizeof(prec->c);
-  pdbRecordType->papFldDes[80]->offset=(short)((char *)&prec->c - (char *)prec);
-  pdbRecordType->papFldDes[81]->size=sizeof(prec->d);
-  pdbRecordType->papFldDes[81]->offset=(short)((char *)&prec->d - (char *)prec);
-  pdbRecordType->papFldDes[82]->size=sizeof(prec->e);
-  pdbRecordType->papFldDes[82]->offset=(short)((char *)&prec->e - (char *)prec);
-  pdbRecordType->papFldDes[83]->size=sizeof(prec->f);
-  pdbRecordType->papFldDes[83]->offset=(short)((char *)&prec->f - (char *)prec);
-  pdbRecordType->papFldDes[84]->size=sizeof(prec->g);
-  pdbRecordType->papFldDes[84]->offset=(short)((char *)&prec->g - (char *)prec);
-  pdbRecordType->papFldDes[85]->size=sizeof(prec->h);
-  pdbRecordType->papFldDes[85]->offset=(short)((char *)&prec->h - (char *)prec);
-  pdbRecordType->papFldDes[86]->size=sizeof(prec->i);
-  pdbRecordType->papFldDes[86]->offset=(short)((char *)&prec->i - (char *)prec);
-  pdbRecordType->papFldDes[87]->size=sizeof(prec->j);
-  pdbRecordType->papFldDes[87]->offset=(short)((char *)&prec->j - (char *)prec);
-  pdbRecordType->papFldDes[88]->size=sizeof(prec->k);
-  pdbRecordType->papFldDes[88]->offset=(short)((char *)&prec->k - (char *)prec);
-  pdbRecordType->papFldDes[89]->size=sizeof(prec->l);
-  pdbRecordType->papFldDes[89]->offset=(short)((char *)&prec->l - (char *)prec);
-  pdbRecordType->papFldDes[90]->size=sizeof(prec->m);
-  pdbRecordType->papFldDes[90]->offset=(short)((char *)&prec->m - (char *)prec);
-  pdbRecordType->papFldDes[91]->size=sizeof(prec->n);
-  pdbRecordType->papFldDes[91]->offset=(short)((char *)&prec->n - (char *)prec);
-  pdbRecordType->papFldDes[92]->size=sizeof(prec->o);
-  pdbRecordType->papFldDes[92]->offset=(short)((char *)&prec->o - (char *)prec);
-  pdbRecordType->papFldDes[93]->size=sizeof(prec->p);
-  pdbRecordType->papFldDes[93]->offset=(short)((char *)&prec->p - (char *)prec);
-  pdbRecordType->papFldDes[94]->size=sizeof(prec->la);
-  pdbRecordType->papFldDes[94]->offset=(short)((char *)&prec->la - (char *)prec);
-  pdbRecordType->papFldDes[95]->size=sizeof(prec->lb);
-  pdbRecordType->papFldDes[95]->offset=(short)((char *)&prec->lb - (char *)prec);
-  pdbRecordType->papFldDes[96]->size=sizeof(prec->lc);
-  pdbRecordType->papFldDes[96]->offset=(short)((char *)&prec->lc - (char *)prec);
-  pdbRecordType->papFldDes[97]->size=sizeof(prec->ld);
-  pdbRecordType->papFldDes[97]->offset=(short)((char *)&prec->ld - (char *)prec);
-  pdbRecordType->papFldDes[98]->size=sizeof(prec->le);
-  pdbRecordType->papFldDes[98]->offset=(short)((char *)&prec->le - (char *)prec);
-  pdbRecordType->papFldDes[99]->size=sizeof(prec->lf);
-  pdbRecordType->papFldDes[99]->offset=(short)((char *)&prec->lf - (char *)prec);
-  pdbRecordType->papFldDes[100]->size=sizeof(prec->lg);
-  pdbRecordType->papFldDes[100]->offset=(short)((char *)&prec->lg - (char *)prec);
-  pdbRecordType->papFldDes[101]->size=sizeof(prec->lh);
-  pdbRecordType->papFldDes[101]->offset=(short)((char *)&prec->lh - (char *)prec);
-  pdbRecordType->papFldDes[102]->size=sizeof(prec->li);
-  pdbRecordType->papFldDes[102]->offset=(short)((char *)&prec->li - (char *)prec);
-  pdbRecordType->papFldDes[103]->size=sizeof(prec->lj);
-  pdbRecordType->papFldDes[103]->offset=(short)((char *)&prec->lj - (char *)prec);
-  pdbRecordType->papFldDes[104]->size=sizeof(prec->lk);
-  pdbRecordType->papFldDes[104]->offset=(short)((char *)&prec->lk - (char *)prec);
-  pdbRecordType->papFldDes[105]->size=sizeof(prec->ll);
-  pdbRecordType->papFldDes[105]->offset=(short)((char *)&prec->ll - (char *)prec);
-  pdbRecordType->papFldDes[106]->size=sizeof(prec->lm);
-  pdbRecordType->papFldDes[106]->offset=(short)((char *)&prec->lm - (char *)prec);
-  pdbRecordType->papFldDes[107]->size=sizeof(prec->ln);
-  pdbRecordType->papFldDes[107]->offset=(short)((char *)&prec->ln - (char *)prec);
-  pdbRecordType->papFldDes[108]->size=sizeof(prec->lo);
-  pdbRecordType->papFldDes[108]->offset=(short)((char *)&prec->lo - (char *)prec);
-  pdbRecordType->papFldDes[109]->size=sizeof(prec->lp);
-  pdbRecordType->papFldDes[109]->offset=(short)((char *)&prec->lp - (char *)prec);
-  pdbRecordType->papFldDes[110]->size=sizeof(prec->lalm);
-  pdbRecordType->papFldDes[110]->offset=(short)((char *)&prec->lalm - (char *)prec);
-  pdbRecordType->papFldDes[111]->size=sizeof(prec->alst);
-  pdbRecordType->papFldDes[111]->offset=(short)((char *)&prec->alst - (char *)prec);
-  pdbRecordType->papFldDes[112]->size=sizeof(prec->mlst);
-  pdbRecordType->papFldDes[112]->offset=(short)((char *)&prec->mlst - (char *)prec);
-  pdbRecordType->papFldDes[113]->size=sizeof(prec->nlst);
-  pdbRecordType->papFldDes[113]->offset=(short)((char *)&prec->nlst - (char *)prec);
-    pdbRecordType->rec_size = sizeof(*prec);
+
+    assert(prt->no_fields == 116);
+    prt->papFldDes[bigselRecordNAME]->size = sizeof(prec->name);
+    prt->papFldDes[bigselRecordDESC]->size = sizeof(prec->desc);
+    prt->papFldDes[bigselRecordASG]->size = sizeof(prec->asg);
+    prt->papFldDes[bigselRecordSCAN]->size = sizeof(prec->scan);
+    prt->papFldDes[bigselRecordPINI]->size = sizeof(prec->pini);
+    prt->papFldDes[bigselRecordPHAS]->size = sizeof(prec->phas);
+    prt->papFldDes[bigselRecordEVNT]->size = sizeof(prec->evnt);
+    prt->papFldDes[bigselRecordTSE]->size = sizeof(prec->tse);
+    prt->papFldDes[bigselRecordTSEL]->size = sizeof(prec->tsel);
+    prt->papFldDes[bigselRecordDTYP]->size = sizeof(prec->dtyp);
+    prt->papFldDes[bigselRecordDISV]->size = sizeof(prec->disv);
+    prt->papFldDes[bigselRecordDISA]->size = sizeof(prec->disa);
+    prt->papFldDes[bigselRecordSDIS]->size = sizeof(prec->sdis);
+    prt->papFldDes[bigselRecordMLOK]->size = sizeof(prec->mlok);
+    prt->papFldDes[bigselRecordMLIS]->size = sizeof(prec->mlis);
+    prt->papFldDes[bigselRecordBKLNK]->size = sizeof(prec->bklnk);
+    prt->papFldDes[bigselRecordDISP]->size = sizeof(prec->disp);
+    prt->papFldDes[bigselRecordPROC]->size = sizeof(prec->proc);
+    prt->papFldDes[bigselRecordSTAT]->size = sizeof(prec->stat);
+    prt->papFldDes[bigselRecordSEVR]->size = sizeof(prec->sevr);
+    prt->papFldDes[bigselRecordNSTA]->size = sizeof(prec->nsta);
+    prt->papFldDes[bigselRecordNSEV]->size = sizeof(prec->nsev);
+    prt->papFldDes[bigselRecordACKS]->size = sizeof(prec->acks);
+    prt->papFldDes[bigselRecordACKT]->size = sizeof(prec->ackt);
+    prt->papFldDes[bigselRecordDISS]->size = sizeof(prec->diss);
+    prt->papFldDes[bigselRecordLCNT]->size = sizeof(prec->lcnt);
+    prt->papFldDes[bigselRecordPACT]->size = sizeof(prec->pact);
+    prt->papFldDes[bigselRecordPUTF]->size = sizeof(prec->putf);
+    prt->papFldDes[bigselRecordRPRO]->size = sizeof(prec->rpro);
+    prt->papFldDes[bigselRecordASP]->size = sizeof(prec->asp);
+    prt->papFldDes[bigselRecordPPN]->size = sizeof(prec->ppn);
+    prt->papFldDes[bigselRecordPPNR]->size = sizeof(prec->ppnr);
+    prt->papFldDes[bigselRecordSPVT]->size = sizeof(prec->spvt);
+    prt->papFldDes[bigselRecordRSET]->size = sizeof(prec->rset);
+    prt->papFldDes[bigselRecordDSET]->size = sizeof(prec->dset);
+    prt->papFldDes[bigselRecordDPVT]->size = sizeof(prec->dpvt);
+    prt->papFldDes[bigselRecordRDES]->size = sizeof(prec->rdes);
+    prt->papFldDes[bigselRecordLSET]->size = sizeof(prec->lset);
+    prt->papFldDes[bigselRecordPRIO]->size = sizeof(prec->prio);
+    prt->papFldDes[bigselRecordTPRO]->size = sizeof(prec->tpro);
+    prt->papFldDes[bigselRecordBKPT]->size = sizeof(prec->bkpt);
+    prt->papFldDes[bigselRecordUDF]->size = sizeof(prec->udf);
+    prt->papFldDes[bigselRecordUDFS]->size = sizeof(prec->udfs);
+    prt->papFldDes[bigselRecordTIME]->size = sizeof(prec->time);
+    prt->papFldDes[bigselRecordFLNK]->size = sizeof(prec->flnk);
+    prt->papFldDes[bigselRecordVAL]->size = sizeof(prec->val);
+    prt->papFldDes[bigselRecordSELM]->size = sizeof(prec->selm);
+    prt->papFldDes[bigselRecordSELN]->size = sizeof(prec->seln);
+    prt->papFldDes[bigselRecordPREC]->size = sizeof(prec->prec);
+    prt->papFldDes[bigselRecordNVL]->size = sizeof(prec->nvl);
+    prt->papFldDes[bigselRecordINPA]->size = sizeof(prec->inpa);
+    prt->papFldDes[bigselRecordINPB]->size = sizeof(prec->inpb);
+    prt->papFldDes[bigselRecordINPC]->size = sizeof(prec->inpc);
+    prt->papFldDes[bigselRecordINPD]->size = sizeof(prec->inpd);
+    prt->papFldDes[bigselRecordINPE]->size = sizeof(prec->inpe);
+    prt->papFldDes[bigselRecordINPF]->size = sizeof(prec->inpf);
+    prt->papFldDes[bigselRecordINPG]->size = sizeof(prec->inpg);
+    prt->papFldDes[bigselRecordINPH]->size = sizeof(prec->inph);
+    prt->papFldDes[bigselRecordINPI]->size = sizeof(prec->inpi);
+    prt->papFldDes[bigselRecordINPJ]->size = sizeof(prec->inpj);
+    prt->papFldDes[bigselRecordINPK]->size = sizeof(prec->inpk);
+    prt->papFldDes[bigselRecordINPL]->size = sizeof(prec->inpl);
+    prt->papFldDes[bigselRecordINPM]->size = sizeof(prec->inpm);
+    prt->papFldDes[bigselRecordINPN]->size = sizeof(prec->inpn);
+    prt->papFldDes[bigselRecordINPO]->size = sizeof(prec->inpo);
+    prt->papFldDes[bigselRecordINPP]->size = sizeof(prec->inpp);
+    prt->papFldDes[bigselRecordEGU]->size = sizeof(prec->egu);
+    prt->papFldDes[bigselRecordHOPR]->size = sizeof(prec->hopr);
+    prt->papFldDes[bigselRecordLOPR]->size = sizeof(prec->lopr);
+    prt->papFldDes[bigselRecordHIHI]->size = sizeof(prec->hihi);
+    prt->papFldDes[bigselRecordLOLO]->size = sizeof(prec->lolo);
+    prt->papFldDes[bigselRecordHIGH]->size = sizeof(prec->high);
+    prt->papFldDes[bigselRecordLOW]->size = sizeof(prec->low);
+    prt->papFldDes[bigselRecordHHSV]->size = sizeof(prec->hhsv);
+    prt->papFldDes[bigselRecordLLSV]->size = sizeof(prec->llsv);
+    prt->papFldDes[bigselRecordHSV]->size = sizeof(prec->hsv);
+    prt->papFldDes[bigselRecordLSV]->size = sizeof(prec->lsv);
+    prt->papFldDes[bigselRecordHYST]->size = sizeof(prec->hyst);
+    prt->papFldDes[bigselRecordADEL]->size = sizeof(prec->adel);
+    prt->papFldDes[bigselRecordMDEL]->size = sizeof(prec->mdel);
+    prt->papFldDes[bigselRecordA]->size = sizeof(prec->a);
+    prt->papFldDes[bigselRecordB]->size = sizeof(prec->b);
+    prt->papFldDes[bigselRecordC]->size = sizeof(prec->c);
+    prt->papFldDes[bigselRecordD]->size = sizeof(prec->d);
+    prt->papFldDes[bigselRecordE]->size = sizeof(prec->e);
+    prt->papFldDes[bigselRecordF]->size = sizeof(prec->f);
+    prt->papFldDes[bigselRecordG]->size = sizeof(prec->g);
+    prt->papFldDes[bigselRecordH]->size = sizeof(prec->h);
+    prt->papFldDes[bigselRecordI]->size = sizeof(prec->i);
+    prt->papFldDes[bigselRecordJ]->size = sizeof(prec->j);
+    prt->papFldDes[bigselRecordK]->size = sizeof(prec->k);
+    prt->papFldDes[bigselRecordL]->size = sizeof(prec->l);
+    prt->papFldDes[bigselRecordM]->size = sizeof(prec->m);
+    prt->papFldDes[bigselRecordN]->size = sizeof(prec->n);
+    prt->papFldDes[bigselRecordO]->size = sizeof(prec->o);
+    prt->papFldDes[bigselRecordP]->size = sizeof(prec->p);
+    prt->papFldDes[bigselRecordLA]->size = sizeof(prec->la);
+    prt->papFldDes[bigselRecordLB]->size = sizeof(prec->lb);
+    prt->papFldDes[bigselRecordLC]->size = sizeof(prec->lc);
+    prt->papFldDes[bigselRecordLD]->size = sizeof(prec->ld);
+    prt->papFldDes[bigselRecordLE]->size = sizeof(prec->le);
+    prt->papFldDes[bigselRecordLF]->size = sizeof(prec->lf);
+    prt->papFldDes[bigselRecordLG]->size = sizeof(prec->lg);
+    prt->papFldDes[bigselRecordLH]->size = sizeof(prec->lh);
+    prt->papFldDes[bigselRecordLI]->size = sizeof(prec->li);
+    prt->papFldDes[bigselRecordLJ]->size = sizeof(prec->lj);
+    prt->papFldDes[bigselRecordLK]->size = sizeof(prec->lk);
+    prt->papFldDes[bigselRecordLL]->size = sizeof(prec->ll);
+    prt->papFldDes[bigselRecordLM]->size = sizeof(prec->lm);
+    prt->papFldDes[bigselRecordLN]->size = sizeof(prec->ln);
+    prt->papFldDes[bigselRecordLO]->size = sizeof(prec->lo);
+    prt->papFldDes[bigselRecordLP]->size = sizeof(prec->lp);
+    prt->papFldDes[bigselRecordLALM]->size = sizeof(prec->lalm);
+    prt->papFldDes[bigselRecordALST]->size = sizeof(prec->alst);
+    prt->papFldDes[bigselRecordMLST]->size = sizeof(prec->mlst);
+    prt->papFldDes[bigselRecordNLST]->size = sizeof(prec->nlst);
+    prt->papFldDes[bigselRecordNAME]->offset = (unsigned short)((char *)&prec->name - (char *)prec);
+    prt->papFldDes[bigselRecordDESC]->offset = (unsigned short)((char *)&prec->desc - (char *)prec);
+    prt->papFldDes[bigselRecordASG]->offset = (unsigned short)((char *)&prec->asg - (char *)prec);
+    prt->papFldDes[bigselRecordSCAN]->offset = (unsigned short)((char *)&prec->scan - (char *)prec);
+    prt->papFldDes[bigselRecordPINI]->offset = (unsigned short)((char *)&prec->pini - (char *)prec);
+    prt->papFldDes[bigselRecordPHAS]->offset = (unsigned short)((char *)&prec->phas - (char *)prec);
+    prt->papFldDes[bigselRecordEVNT]->offset = (unsigned short)((char *)&prec->evnt - (char *)prec);
+    prt->papFldDes[bigselRecordTSE]->offset = (unsigned short)((char *)&prec->tse - (char *)prec);
+    prt->papFldDes[bigselRecordTSEL]->offset = (unsigned short)((char *)&prec->tsel - (char *)prec);
+    prt->papFldDes[bigselRecordDTYP]->offset = (unsigned short)((char *)&prec->dtyp - (char *)prec);
+    prt->papFldDes[bigselRecordDISV]->offset = (unsigned short)((char *)&prec->disv - (char *)prec);
+    prt->papFldDes[bigselRecordDISA]->offset = (unsigned short)((char *)&prec->disa - (char *)prec);
+    prt->papFldDes[bigselRecordSDIS]->offset = (unsigned short)((char *)&prec->sdis - (char *)prec);
+    prt->papFldDes[bigselRecordMLOK]->offset = (unsigned short)((char *)&prec->mlok - (char *)prec);
+    prt->papFldDes[bigselRecordMLIS]->offset = (unsigned short)((char *)&prec->mlis - (char *)prec);
+    prt->papFldDes[bigselRecordBKLNK]->offset = (unsigned short)((char *)&prec->bklnk - (char *)prec);
+    prt->papFldDes[bigselRecordDISP]->offset = (unsigned short)((char *)&prec->disp - (char *)prec);
+    prt->papFldDes[bigselRecordPROC]->offset = (unsigned short)((char *)&prec->proc - (char *)prec);
+    prt->papFldDes[bigselRecordSTAT]->offset = (unsigned short)((char *)&prec->stat - (char *)prec);
+    prt->papFldDes[bigselRecordSEVR]->offset = (unsigned short)((char *)&prec->sevr - (char *)prec);
+    prt->papFldDes[bigselRecordNSTA]->offset = (unsigned short)((char *)&prec->nsta - (char *)prec);
+    prt->papFldDes[bigselRecordNSEV]->offset = (unsigned short)((char *)&prec->nsev - (char *)prec);
+    prt->papFldDes[bigselRecordACKS]->offset = (unsigned short)((char *)&prec->acks - (char *)prec);
+    prt->papFldDes[bigselRecordACKT]->offset = (unsigned short)((char *)&prec->ackt - (char *)prec);
+    prt->papFldDes[bigselRecordDISS]->offset = (unsigned short)((char *)&prec->diss - (char *)prec);
+    prt->papFldDes[bigselRecordLCNT]->offset = (unsigned short)((char *)&prec->lcnt - (char *)prec);
+    prt->papFldDes[bigselRecordPACT]->offset = (unsigned short)((char *)&prec->pact - (char *)prec);
+    prt->papFldDes[bigselRecordPUTF]->offset = (unsigned short)((char *)&prec->putf - (char *)prec);
+    prt->papFldDes[bigselRecordRPRO]->offset = (unsigned short)((char *)&prec->rpro - (char *)prec);
+    prt->papFldDes[bigselRecordASP]->offset = (unsigned short)((char *)&prec->asp - (char *)prec);
+    prt->papFldDes[bigselRecordPPN]->offset = (unsigned short)((char *)&prec->ppn - (char *)prec);
+    prt->papFldDes[bigselRecordPPNR]->offset = (unsigned short)((char *)&prec->ppnr - (char *)prec);
+    prt->papFldDes[bigselRecordSPVT]->offset = (unsigned short)((char *)&prec->spvt - (char *)prec);
+    prt->papFldDes[bigselRecordRSET]->offset = (unsigned short)((char *)&prec->rset - (char *)prec);
+    prt->papFldDes[bigselRecordDSET]->offset = (unsigned short)((char *)&prec->dset - (char *)prec);
+    prt->papFldDes[bigselRecordDPVT]->offset = (unsigned short)((char *)&prec->dpvt - (char *)prec);
+    prt->papFldDes[bigselRecordRDES]->offset = (unsigned short)((char *)&prec->rdes - (char *)prec);
+    prt->papFldDes[bigselRecordLSET]->offset = (unsigned short)((char *)&prec->lset - (char *)prec);
+    prt->papFldDes[bigselRecordPRIO]->offset = (unsigned short)((char *)&prec->prio - (char *)prec);
+    prt->papFldDes[bigselRecordTPRO]->offset = (unsigned short)((char *)&prec->tpro - (char *)prec);
+    prt->papFldDes[bigselRecordBKPT]->offset = (unsigned short)((char *)&prec->bkpt - (char *)prec);
+    prt->papFldDes[bigselRecordUDF]->offset = (unsigned short)((char *)&prec->udf - (char *)prec);
+    prt->papFldDes[bigselRecordUDFS]->offset = (unsigned short)((char *)&prec->udfs - (char *)prec);
+    prt->papFldDes[bigselRecordTIME]->offset = (unsigned short)((char *)&prec->time - (char *)prec);
+    prt->papFldDes[bigselRecordFLNK]->offset = (unsigned short)((char *)&prec->flnk - (char *)prec);
+    prt->papFldDes[bigselRecordVAL]->offset = (unsigned short)((char *)&prec->val - (char *)prec);
+    prt->papFldDes[bigselRecordSELM]->offset = (unsigned short)((char *)&prec->selm - (char *)prec);
+    prt->papFldDes[bigselRecordSELN]->offset = (unsigned short)((char *)&prec->seln - (char *)prec);
+    prt->papFldDes[bigselRecordPREC]->offset = (unsigned short)((char *)&prec->prec - (char *)prec);
+    prt->papFldDes[bigselRecordNVL]->offset = (unsigned short)((char *)&prec->nvl - (char *)prec);
+    prt->papFldDes[bigselRecordINPA]->offset = (unsigned short)((char *)&prec->inpa - (char *)prec);
+    prt->papFldDes[bigselRecordINPB]->offset = (unsigned short)((char *)&prec->inpb - (char *)prec);
+    prt->papFldDes[bigselRecordINPC]->offset = (unsigned short)((char *)&prec->inpc - (char *)prec);
+    prt->papFldDes[bigselRecordINPD]->offset = (unsigned short)((char *)&prec->inpd - (char *)prec);
+    prt->papFldDes[bigselRecordINPE]->offset = (unsigned short)((char *)&prec->inpe - (char *)prec);
+    prt->papFldDes[bigselRecordINPF]->offset = (unsigned short)((char *)&prec->inpf - (char *)prec);
+    prt->papFldDes[bigselRecordINPG]->offset = (unsigned short)((char *)&prec->inpg - (char *)prec);
+    prt->papFldDes[bigselRecordINPH]->offset = (unsigned short)((char *)&prec->inph - (char *)prec);
+    prt->papFldDes[bigselRecordINPI]->offset = (unsigned short)((char *)&prec->inpi - (char *)prec);
+    prt->papFldDes[bigselRecordINPJ]->offset = (unsigned short)((char *)&prec->inpj - (char *)prec);
+    prt->papFldDes[bigselRecordINPK]->offset = (unsigned short)((char *)&prec->inpk - (char *)prec);
+    prt->papFldDes[bigselRecordINPL]->offset = (unsigned short)((char *)&prec->inpl - (char *)prec);
+    prt->papFldDes[bigselRecordINPM]->offset = (unsigned short)((char *)&prec->inpm - (char *)prec);
+    prt->papFldDes[bigselRecordINPN]->offset = (unsigned short)((char *)&prec->inpn - (char *)prec);
+    prt->papFldDes[bigselRecordINPO]->offset = (unsigned short)((char *)&prec->inpo - (char *)prec);
+    prt->papFldDes[bigselRecordINPP]->offset = (unsigned short)((char *)&prec->inpp - (char *)prec);
+    prt->papFldDes[bigselRecordEGU]->offset = (unsigned short)((char *)&prec->egu - (char *)prec);
+    prt->papFldDes[bigselRecordHOPR]->offset = (unsigned short)((char *)&prec->hopr - (char *)prec);
+    prt->papFldDes[bigselRecordLOPR]->offset = (unsigned short)((char *)&prec->lopr - (char *)prec);
+    prt->papFldDes[bigselRecordHIHI]->offset = (unsigned short)((char *)&prec->hihi - (char *)prec);
+    prt->papFldDes[bigselRecordLOLO]->offset = (unsigned short)((char *)&prec->lolo - (char *)prec);
+    prt->papFldDes[bigselRecordHIGH]->offset = (unsigned short)((char *)&prec->high - (char *)prec);
+    prt->papFldDes[bigselRecordLOW]->offset = (unsigned short)((char *)&prec->low - (char *)prec);
+    prt->papFldDes[bigselRecordHHSV]->offset = (unsigned short)((char *)&prec->hhsv - (char *)prec);
+    prt->papFldDes[bigselRecordLLSV]->offset = (unsigned short)((char *)&prec->llsv - (char *)prec);
+    prt->papFldDes[bigselRecordHSV]->offset = (unsigned short)((char *)&prec->hsv - (char *)prec);
+    prt->papFldDes[bigselRecordLSV]->offset = (unsigned short)((char *)&prec->lsv - (char *)prec);
+    prt->papFldDes[bigselRecordHYST]->offset = (unsigned short)((char *)&prec->hyst - (char *)prec);
+    prt->papFldDes[bigselRecordADEL]->offset = (unsigned short)((char *)&prec->adel - (char *)prec);
+    prt->papFldDes[bigselRecordMDEL]->offset = (unsigned short)((char *)&prec->mdel - (char *)prec);
+    prt->papFldDes[bigselRecordA]->offset = (unsigned short)((char *)&prec->a - (char *)prec);
+    prt->papFldDes[bigselRecordB]->offset = (unsigned short)((char *)&prec->b - (char *)prec);
+    prt->papFldDes[bigselRecordC]->offset = (unsigned short)((char *)&prec->c - (char *)prec);
+    prt->papFldDes[bigselRecordD]->offset = (unsigned short)((char *)&prec->d - (char *)prec);
+    prt->papFldDes[bigselRecordE]->offset = (unsigned short)((char *)&prec->e - (char *)prec);
+    prt->papFldDes[bigselRecordF]->offset = (unsigned short)((char *)&prec->f - (char *)prec);
+    prt->papFldDes[bigselRecordG]->offset = (unsigned short)((char *)&prec->g - (char *)prec);
+    prt->papFldDes[bigselRecordH]->offset = (unsigned short)((char *)&prec->h - (char *)prec);
+    prt->papFldDes[bigselRecordI]->offset = (unsigned short)((char *)&prec->i - (char *)prec);
+    prt->papFldDes[bigselRecordJ]->offset = (unsigned short)((char *)&prec->j - (char *)prec);
+    prt->papFldDes[bigselRecordK]->offset = (unsigned short)((char *)&prec->k - (char *)prec);
+    prt->papFldDes[bigselRecordL]->offset = (unsigned short)((char *)&prec->l - (char *)prec);
+    prt->papFldDes[bigselRecordM]->offset = (unsigned short)((char *)&prec->m - (char *)prec);
+    prt->papFldDes[bigselRecordN]->offset = (unsigned short)((char *)&prec->n - (char *)prec);
+    prt->papFldDes[bigselRecordO]->offset = (unsigned short)((char *)&prec->o - (char *)prec);
+    prt->papFldDes[bigselRecordP]->offset = (unsigned short)((char *)&prec->p - (char *)prec);
+    prt->papFldDes[bigselRecordLA]->offset = (unsigned short)((char *)&prec->la - (char *)prec);
+    prt->papFldDes[bigselRecordLB]->offset = (unsigned short)((char *)&prec->lb - (char *)prec);
+    prt->papFldDes[bigselRecordLC]->offset = (unsigned short)((char *)&prec->lc - (char *)prec);
+    prt->papFldDes[bigselRecordLD]->offset = (unsigned short)((char *)&prec->ld - (char *)prec);
+    prt->papFldDes[bigselRecordLE]->offset = (unsigned short)((char *)&prec->le - (char *)prec);
+    prt->papFldDes[bigselRecordLF]->offset = (unsigned short)((char *)&prec->lf - (char *)prec);
+    prt->papFldDes[bigselRecordLG]->offset = (unsigned short)((char *)&prec->lg - (char *)prec);
+    prt->papFldDes[bigselRecordLH]->offset = (unsigned short)((char *)&prec->lh - (char *)prec);
+    prt->papFldDes[bigselRecordLI]->offset = (unsigned short)((char *)&prec->li - (char *)prec);
+    prt->papFldDes[bigselRecordLJ]->offset = (unsigned short)((char *)&prec->lj - (char *)prec);
+    prt->papFldDes[bigselRecordLK]->offset = (unsigned short)((char *)&prec->lk - (char *)prec);
+    prt->papFldDes[bigselRecordLL]->offset = (unsigned short)((char *)&prec->ll - (char *)prec);
+    prt->papFldDes[bigselRecordLM]->offset = (unsigned short)((char *)&prec->lm - (char *)prec);
+    prt->papFldDes[bigselRecordLN]->offset = (unsigned short)((char *)&prec->ln - (char *)prec);
+    prt->papFldDes[bigselRecordLO]->offset = (unsigned short)((char *)&prec->lo - (char *)prec);
+    prt->papFldDes[bigselRecordLP]->offset = (unsigned short)((char *)&prec->lp - (char *)prec);
+    prt->papFldDes[bigselRecordLALM]->offset = (unsigned short)((char *)&prec->lalm - (char *)prec);
+    prt->papFldDes[bigselRecordALST]->offset = (unsigned short)((char *)&prec->alst - (char *)prec);
+    prt->papFldDes[bigselRecordMLST]->offset = (unsigned short)((char *)&prec->mlst - (char *)prec);
+    prt->papFldDes[bigselRecordNLST]->offset = (unsigned short)((char *)&prec->nlst - (char *)prec);
+    prt->rec_size = sizeof(*prec);
     return(0);
 }
 epicsExportRegistrar(bigselRecordSizeOffset);
@@ -490,3 +508,5 @@ epicsExportRegistrar(bigselRecordSizeOffset);
 }
 #endif
 #endif /*GEN_SIZE_OFFSET*/
+
+#endif /* INC_bigselRecord_H */ 

--- a/ipimbLib/src/devIpimbGenSub.c
+++ b/ipimbLib/src/devIpimbGenSub.c
@@ -133,9 +133,16 @@ long ipimbDoReadProc(struct aSubRecord *psub)
     return 0;
 }
 
+long ipimbGetFiducial(struct aSubRecord *psub)
+{
+	recGblGetTimeStamp( psub );
+	return psub->time.nsec & 0x1ffff;
+}
+
 epicsRegisterFunction(ipimbConfigInit);
 epicsRegisterFunction(ipimbConfigProc);
 epicsRegisterFunction(ipimbDoReadProc);
+epicsRegisterFunction(ipimbGetFiducial);
 
 #ifdef  __cplusplus
 }

--- a/ipimbLib/src/drvIpimb.cpp
+++ b/ipimbLib/src/drvIpimb.cpp
@@ -113,12 +113,14 @@ static int ipimbSetPv(int iPvIndex, void* pPvValue, void* payload)
     return 0;
 }
 
-int	 ipimbAdd(char *name, char *ttyName, char *mdestIP, unsigned int physID, unsigned int dtype,
-                  char *trigger, int polarity, char *delay, char *sync)
+int  ipimbAdd(char *name, char *ttyName, char *mdestIP, unsigned int physID, unsigned int dtype,
+              char* gen, char *trigger, int polarity, char *delay, char *sync)
 {
     IPIMB_DEVICE  * pdevice = NULL;
     DBADDR trigaddr;
+    DBADDR genaddr;
     static epicsUInt32 ev140 = 140;
+    static epicsUInt32 gen0 = 0;
 
     /*
      * Sigh.  The joys of backwards compatibility.
@@ -175,10 +177,20 @@ int	 ipimbAdd(char *name, char *ttyName, char *mdestIP, unsigned int physID, uns
         pdevice = new IPIMB_DEVICE(name, ttyName, mdestIP, physID, &ev140, &ev140, polarity, delay, sync);
     } else {
         epicsUInt32 *trig = (epicsUInt32 *) trigaddr.pfield;
+        epicsUInt32 *genp = NULL;
+        if (!gen) {
+          // if gen is null then we using an ever so use the magic offset...
+          genp = trig + MAX_EV_TRIGGERS;
+        } else if (dbNameToAddr(gen, &genaddr)) {
+          printf("No PV gen named %s, using constant gen 0!\n", gen);
+          genp = &gen0;
+        } else {
+          genp = (epicsUInt32 *) genaddr.pfield;
+        }
         printf("Found PV trigger for IPIMB%d %s at %p (gen at %p)\n", 
-               physID, trigger, trig, trig + MAX_EV_TRIGGERS);
+               physID, trigger, trig, genp);
         pdevice = new IPIMB_DEVICE(name, ttyName, mdestIP, physID,
-                                   trig, trig + MAX_EV_TRIGGERS, polarity, delay, sync);
+                                   trig, genp, polarity, delay, sync);
     }
 
     /* Add to the device linked list */

--- a/ipimbLib/src/drvIpimb.h
+++ b/ipimbLib/src/drvIpimb.h
@@ -131,7 +131,8 @@ int ipimbConfigureByName(char * ipimbName, uint16_t chargeAmpRange,
 IPIMB_DEVICE * ipimbFindDeviceByName(char * name);
 IPIMB_DEVICE * ipimbFindDeviceByTtyName(char * ttyName);
 int		ipimbAdd(char * name, char * ttyName, char * mdestIP, unsigned int physID,
-                         unsigned int dtype, char *trigger, int polarity, char *delay, char *sync );
+               unsigned int dtype, char *gen, char *trigger, int polarity,
+               char *delay, char *sync );
 
 void ipimbStart(void);
 #ifdef	__cplusplus

--- a/ipimbLib/src/drvIpimbRegister.cpp
+++ b/ipimbLib/src/drvIpimbRegister.cpp
@@ -50,19 +50,31 @@ static const iocshArg ipimbAddArg1 = {"ttyName", iocshArgString};
 static const iocshArg ipimbAddArg2 = {"mdestIP", iocshArgString};
 static const iocshArg ipimbAddArg3 = {"physID", iocshArgInt};
 static const iocshArg ipimbAddArg4 = {"datatype", iocshArgInt};
-static const iocshArg ipimbAddArg5 = {"trigger", iocshArgString};
-static const iocshArg ipimbAddArg6 = {"polarity", iocshArgInt};
-static const iocshArg ipimbAddArg7 = {"delay", iocshArgString};
-static const iocshArg ipimbAddArg8 = {"sync", iocshArgString};
+static const iocshArg ipimbAddArg5 = {"gen", iocshArgString};
+static const iocshArg ipimbAddArg6 = {"trigger", iocshArgString};
+static const iocshArg ipimbAddArg7 = {"polarity", iocshArgInt};
+static const iocshArg ipimbAddArg8 = {"delay", iocshArgString};
+static const iocshArg ipimbAddArg9 = {"sync", iocshArgString};
 static const iocshArg *const ipimbAddArgs[9] = {&ipimbAddArg0, &ipimbAddArg1, &ipimbAddArg2, &ipimbAddArg3,
-                                                &ipimbAddArg4, &ipimbAddArg5, &ipimbAddArg6, &ipimbAddArg7,
-                                                &ipimbAddArg8};
+                                                &ipimbAddArg4, &ipimbAddArg6, &ipimbAddArg7, &ipimbAddArg8,
+                                                &ipimbAddArg9};
 static const iocshFuncDef ipimbAddDef = {"ipimbAdd", 9, ipimbAddArgs};
 static void ipimbAddCall(const iocshArgBuf * args) {
     ipimbAdd( (char *)(args[0].sval), (char *)(args[1].sval), (char *)(args[2].sval),
               (unsigned int) args[3].ival, (unsigned int) args[4].ival,
-              (char *)(args[5].sval), args[6].ival, (char *)(args[7].sval),
-              (char *)(args[8].sval));
+              NULL, (char *)(args[6].sval), args[7].ival,
+              (char *)(args[8].sval), (char *)(args[9].sval));
+}
+
+static const iocshArg *const ipimbTprAddArgs[10] = {&ipimbAddArg0, &ipimbAddArg1, &ipimbAddArg2, &ipimbAddArg3,
+                                                    &ipimbAddArg4, &ipimbAddArg5, &ipimbAddArg6, &ipimbAddArg7,
+                                                    &ipimbAddArg8, &ipimbAddArg9};
+static const iocshFuncDef ipimbTprAddDef = {"ipimbTprAdd", 10, ipimbTprAddArgs};
+static void ipimbTprAddCall(const iocshArgBuf * args) {
+    ipimbAdd( (char *)(args[0].sval), (char *)(args[1].sval), (char *)(args[2].sval),
+              (unsigned int) args[3].ival, (unsigned int) args[4].ival,
+              (char *)(args[5].sval), (char *)(args[6].sval), args[7].ival,
+              (char *)(args[8].sval), (char *)(args[9].sval));
 }
 
 static const iocshFuncDef ipimbStartDef = {"ipimbStart", 0, NULL};
@@ -80,6 +92,7 @@ void drvIPIMB_Register() {
         iocshRegister(&IPIMB_BRD_DEBUGDef, IPIMB_BRD_DEBUGCall);
         iocshRegister(&IPIMB_BRD_IDDef,    IPIMB_BRD_IDCall);
         iocshRegister(&ipimbAddDef, ipimbAddCall);
+        iocshRegister(&ipimbTprAddDef, ipimbTprAddCall);
         iocshRegister(&ipimbStartDef, ipimbStartCall);
 }
 #ifdef __cplusplus

--- a/ipimbLib/src/ipimbsync.cc
+++ b/ipimbLib/src/ipimbsync.cc
@@ -2,6 +2,8 @@
 
 #include "timingFifoApi.h"
 
+#include <inttypes.h>
+
 using namespace std;
 using namespace Pds;
 
@@ -60,7 +62,7 @@ DataObject *ipimbSyncObject::Acquire(void)
         }
         did_skip = 0;
         if (DBG_ENABLED(DEBUG_TC_V) && !COMMAND(rdbuf[0])) {
-            printf("IPIMB %s data read @ fid 0x%x\n", ipimb->_name, timingGetLastFiducial());
+            printf("IPIMB %s data read @ fid 0x%" PRIx64 "\n", ipimb->_name, timingGetLastFiducial());
             fflush(stdout);
         }
 


### PR DESCRIPTION
This part of fixes to the ipimb IOCs so that they work in epics7 and with tprs. This was motivated by the desire to replace existing ioc hosts for the XRT ipimbs with new machines running rocky9 and tprs.

Main changes:
1. I split the evr specific records (that are needed by timesync) out of ipimbALL.tpl-db into a separate ipimbSyncEvr.tpl-db file. They get combined into ipimb.db that is the same as before. I also made ipimbSyncTpr.tpl-db for tpr case that gets combined into ipimbTpr.db. ipimbSyncTpr.tpl-db also adds a GEN record that increments when the settings for the tpr channel are changed. This is used by timesync and mimics the behavior of the evr case. Also for the tpr case we pass 1000+chnum as the "evtcode" that timesync eventually passes to timingFifoRead.
2. Added a ipimbTprAdd iocsh function so we can pass the name of the GEN record down to timesync in the tpr case. For evr the module finds the address of the right gen field to pass to timesync via pointer arithmetic from the address of the channel eventcode field of the Trigger record (from event2). I could have also just added another arg to ipimbAdd instead and then IOCs using the module would always have to explicitly pass the name of the "gen" field and then no more pointer math to find the address. That is probably the more correct way, but its not backwards compatible for the existing iocs using evrs. Its easy to change this if we just want to always pass the name of the gen field.
3. The custom bigselRecord included in this module would cause the IOC to segfault on epics7 when the record processed. I updated it to be more "modern" and it is now working fine. Do we need this to still work on 3.14? 
4. evrTimeGetFiducial which is used as the SNAM in a aSub record is being pulled from event2 so we don't have a version of it with the tpr. I defined a function ipimbGetFiducial which does the same thing. I left the evr version of the main db file using evrTimeGetFiducial. It might be simpler just to always use ipimbGetFiducial?

We have one of the XRT ipimbs connected to the planned replacement machine, and I tested these changes. The timestamping looks good and it working now.