### PR TITLE
Add suggeset cleanup and error checking for iocsh functions

### DIFF
--- a/ipimbLib/src/IpimBoard.cc
+++ b/ipimbLib/src/IpimBoard.cc
@@ -155,8 +155,8 @@ static void *ipimb_configure_body(void *p)
     return NULL;
 }
 
-IpimBoard::IpimBoard(char* serialDevice, IOSCANPVT *ioscan, int physID, epicsUInt32* trigger,
-                     epicsUInt32 *gen, int polarity, char *delay, char *name, char *sync)
+IpimBoard::IpimBoard(const char* serialDevice, IOSCANPVT *ioscan, int physID, epicsUInt32* trigger,
+                     epicsUInt32 *gen, int polarity, const char *delay, const char *name, const char *sync)
 {
     struct termios newtio;
 

--- a/ipimbLib/src/IpimBoard.hh
+++ b/ipimbLib/src/IpimBoard.hh
@@ -217,8 +217,8 @@ namespace Pds {
             vhdl_version        = 0x17
         };
 
-        IpimBoard(char* serialDevice, IOSCANPVT *ioscan, int physID, epicsUInt32 *trigger,
-                  epicsUInt32 *gen, int polarity, char *delay, char *name, char *sync);
+        IpimBoard(const char* serialDevice, IOSCANPVT *ioscan, int physID, epicsUInt32 *trigger,
+                  epicsUInt32 *gen, int polarity, const char *delay, const char *name, const char *sync);
         ~IpimBoard();
 
         void do_configure(void);  // The configure thread body!

--- a/ipimbLib/src/drvIpimb.cpp
+++ b/ipimbLib/src/drvIpimb.cpp
@@ -49,7 +49,7 @@ int ipimbConfigureByName(char * ipimbName, uint16_t chargeAmpRange,
 }
 
 /* This function is used to check if the ipimb box name already in our list */
-IPIMB_DEVICE * ipimbFindDeviceByName(char * name)
+IPIMB_DEVICE * ipimbFindDeviceByName(const char * name)
 {
     IPIMB_DEVICE  * pdevice = NULL;
 
@@ -66,7 +66,7 @@ IPIMB_DEVICE * ipimbFindDeviceByName(char * name)
 }
 
 /* This function is used to check if the ttyName already in our list */
-IPIMB_DEVICE * ipimbFindDeviceByTtyName(char * ttyName)
+IPIMB_DEVICE * ipimbFindDeviceByTtyName(const char * ttyName)
 {
     IPIMB_DEVICE  * pdevice = NULL;
 
@@ -113,8 +113,8 @@ static int ipimbSetPv(int iPvIndex, void* pPvValue, void* payload)
     return 0;
 }
 
-int  ipimbAdd(char *name, char *ttyName, char *mdestIP, unsigned int physID, unsigned int dtype,
-              char* gen, char *trigger, int polarity, char *delay, char *sync)
+int  ipimbAdd(const char *name, const char *ttyName, const char *mdestIP, unsigned int physID, unsigned int dtype,
+              const char* gen, const char *trigger, int polarity, const char *delay, const char *sync)
 {
     IPIMB_DEVICE  * pdevice = NULL;
     DBADDR trigaddr;
@@ -226,7 +226,7 @@ static long IPIMB_EPICS_Report(int level)
 {
     IPIMB_DEVICE * pdevice;
 
-    printf("\n"IPIMB_DRV_VERSION"\n\n");
+    printf("\n" IPIMB_DRV_VERSION "\n\n");
 
     if(!IPIMB_device_list_inited)
     {

--- a/ipimbLib/src/drvIpimb.h
+++ b/ipimbLib/src/drvIpimb.h
@@ -91,8 +91,8 @@ public:
     IpimBoardData    ipmData;
 
 public:
-    IPIMB_DEVICE(char * ipmName, char *ipmTtyName, char * ipmMdestIP, int physID, 
-                 epicsUInt32 *trigger, epicsUInt32 *gen, int polarity, char *delay, char *sync)
+    IPIMB_DEVICE(const char * ipmName, const char *ipmTtyName, const char * ipmMdestIP, int physID,
+                 epicsUInt32 *trigger, epicsUInt32 *gen, int polarity, const char *delay, const char *sync)
         : ipmBoard(ipmTtyName, &ioscan, physID, trigger, gen, polarity, delay, ipmName, sync), ipmData()
     {
         name = epicsStrDup(ipmName);
@@ -128,11 +128,11 @@ int ipimbConfigureByName(char * ipimbName, uint16_t chargeAmpRange,
                          uint16_t calStrobeLength, uint32_t trigDelay, 
                          uint32_t trigPsDelay, uint32_t adcDelay,
                          DBLINK *trig);
-IPIMB_DEVICE * ipimbFindDeviceByName(char * name);
-IPIMB_DEVICE * ipimbFindDeviceByTtyName(char * ttyName);
-int		ipimbAdd(char * name, char * ttyName, char * mdestIP, unsigned int physID,
-               unsigned int dtype, char *gen, char *trigger, int polarity,
-               char *delay, char *sync );
+IPIMB_DEVICE * ipimbFindDeviceByName(const char * name);
+IPIMB_DEVICE * ipimbFindDeviceByTtyName(const char * ttyName);
+int		ipimbAdd(const char * name, const char * ttyName, const char * mdestIP, unsigned int physID,
+               unsigned int dtype, const char *gen, const char *trigger, int polarity,
+               const char *delay, const char *sync );
 
 void ipimbStart(void);
 #ifdef	__cplusplus

--- a/ipimbLib/src/drvIpimbRegister.cpp
+++ b/ipimbLib/src/drvIpimbRegister.cpp
@@ -60,10 +60,22 @@ static const iocshArg *const ipimbAddArgs[9] = {&ipimbAddArg0, &ipimbAddArg1, &i
                                                 &ipimbAddArg9};
 static const iocshFuncDef ipimbAddDef = {"ipimbAdd", 9, ipimbAddArgs};
 static void ipimbAddCall(const iocshArgBuf * args) {
-    ipimbAdd( (char *)(args[0].sval), (char *)(args[1].sval), (char *)(args[2].sval),
-              (unsigned int) args[3].ival, (unsigned int) args[4].ival,
-              NULL, (char *)(args[6].sval), args[7].ival,
-              (char *)(args[8].sval), (char *)(args[9].sval));
+    int retcode = 0;
+    // null check all the string arguments
+    for (int idx=0; idx<ipimbAddDef.nargs; idx++) {
+      if ((ipimbAddArgs[idx]->type == iocshArgString) && !args[idx].sval) {
+        printf("%s string argument %s (%d) must be non-null!\n",
+               ipimbAddDef.name, ipimbAddArgs[idx]->name, idx);
+        retcode = 1;
+      }
+    }
+    if (retcode == 0) {
+      retcode = ipimbAdd( args[0].sval, args[1].sval, args[2].sval,
+                          (unsigned int) args[3].ival, (unsigned int) args[4].ival,
+                          NULL, args[6].sval, args[7].ival,
+                          args[8].sval, args[9].sval);
+    }
+    iocshSetError(retcode);
 }
 
 static const iocshArg *const ipimbTprAddArgs[10] = {&ipimbAddArg0, &ipimbAddArg1, &ipimbAddArg2, &ipimbAddArg3,
@@ -71,10 +83,22 @@ static const iocshArg *const ipimbTprAddArgs[10] = {&ipimbAddArg0, &ipimbAddArg1
                                                     &ipimbAddArg8, &ipimbAddArg9};
 static const iocshFuncDef ipimbTprAddDef = {"ipimbTprAdd", 10, ipimbTprAddArgs};
 static void ipimbTprAddCall(const iocshArgBuf * args) {
-    ipimbAdd( (char *)(args[0].sval), (char *)(args[1].sval), (char *)(args[2].sval),
-              (unsigned int) args[3].ival, (unsigned int) args[4].ival,
-              (char *)(args[5].sval), (char *)(args[6].sval), args[7].ival,
-              (char *)(args[8].sval), (char *)(args[9].sval));
+    int retcode = 0;
+    // null check all the string arguments
+    for (int idx=0; idx<ipimbTprAddDef.nargs; idx++) {
+      if ((ipimbTprAddArgs[idx]->type == iocshArgString) && !args[idx].sval) {
+        printf("%s string argument %s (%d) must be non-null!\n",
+               ipimbTprAddDef.name, ipimbTprAddArgs[idx]->name, idx);
+        retcode = 1;
+      }
+    }
+    if (retcode == 0) {
+      retcode = ipimbAdd( args[0].sval, args[1].sval, args[2].sval,
+                          (unsigned int) args[3].ival, (unsigned int) args[4].ival,
+                          args[5].sval, args[6].sval, args[7].ival,
+                          args[8].sval, args[9].sval);
+    }
+    iocshSetError(retcode);
 }
 
 static const iocshFuncDef ipimbStartDef = {"ipimbStart", 0, NULL};


### PR DESCRIPTION
This is the suggested cleanup and error checking for the iocsh functions suggested in the previous pull request. Checks that none of the strings arguments are NULL. Also changes the pass strings to const char to avoid all the casting.